### PR TITLE
Brackets endpoint

### DIFF
--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -155,7 +155,6 @@ class RoundsController < ApplicationController
     players = pairings_data_players
     @tournament.stages.includes(:rounds).map do |stage|
       {
-        number: stage.number,
         name: stage.format.titleize,
         format: stage.format,
         is_single_sided: stage.single_sided?,

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -236,6 +236,7 @@ class RoundsController < ApplicationController
         self_report: self_report_result,
         round: bracket_game ? bracket_game[:round] : nil,
         winner_game: bracket_game ? bracket_game[:winner_game] : nil,
+        loser_game: bracket_game ? bracket_game[:loser_game] : nil,
         bracket_type: bracket_game ? bracket_game[:bracket_type] : nil
       }
     end
@@ -354,6 +355,7 @@ class RoundsController < ApplicationController
         table_number: game[:number],
         round: game[:round],
         winner_game: game[:winner_game],
+        loser_game: game[:loser_game],
         bracket_type: game[:bracket_type].to_s
       }
     end

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -31,6 +31,45 @@ class RoundsController < ApplicationController
     }
   end
 
+  def brackets
+    authorize @tournament, :show?
+
+    # Load pairing data for elimination stages
+    stages = pairings_data_stages
+    stages.each do |stage|
+      bracket_info = bracket_games(stage)
+      next if bracket_info.nil?
+
+      stage[:rounds].each do |round|
+        bracket_round = bracket_info&.select { |g| g[:round] == round[:number] }
+        next if bracket_round.nil?
+
+        # Add bracket information to the pairings
+        round[:pairings].each do |pairing|
+          bracket_game = bracket_round&.find { |g| g[:table_number] == pairing[:table_number] }
+
+          pairing[:round] = bracket_game ? bracket_game[:round] : nil
+          pairing[:winner_game] = bracket_game ? bracket_game[:winner_game] : nil
+          pairing[:loser_game] = bracket_game ? bracket_game[:loser_game] : nil
+          pairing[:bracket_type] = bracket_game ? bracket_game[:bracket_type] : nil
+        end
+      end
+
+      # Add bracket information for rounds not yet paired
+      bracket_info&.group_by { |g| g[:round] }&.each do |round, games|
+        next if stage[:rounds].any? { |r| r[:number] == round }
+
+        stage[:rounds] << {
+          id: nil,
+          number: round,
+          pairings: games
+        }
+      end
+    end
+
+    render json: { stages: }
+  end
+
   def show
     authorize @tournament, :update?
     @round = Round.includes([:stage, { pairings: %i[stage tournament player1 player2 self_reports] }]).find(params[:id])
@@ -116,11 +155,13 @@ class RoundsController < ApplicationController
     players = pairings_data_players
     @tournament.stages.includes(:rounds).map do |stage|
       {
+        number: stage.number,
         name: stage.format.titleize,
         format: stage.format,
         is_single_sided: stage.single_sided?,
         is_elimination: stage.elimination?,
-        rounds: pairings_data_rounds(stage, players)
+        rounds: pairings_data_rounds(stage, players),
+        player_count: stage.players.count
       }
     end
   end
@@ -151,28 +192,14 @@ class RoundsController < ApplicationController
 
   def pairings_data_rounds(stage, players)
     view_decks = stage.decks_visible_to(current_user) ? true : false
-    bracket_info = bracket_games(stage)
 
     # Get data for all paired rounds
-    rounds = stage.rounds.map do |round|
-      pairings_data_round(stage, players, view_decks, round, bracket_info&.select { |g| g[:round] == round.number })
+    stage.rounds.map do |round|
+      pairings_data_round(stage, players, view_decks, round)
     end
-
-    # Add bracket information for rounds not yet paired
-    bracket_info&.group_by { |g| g[:round] }&.each do |round, games|
-      next if rounds.any? { |r| r[:number] == round }
-
-      rounds << {
-        id: nil,
-        number: round,
-        pairings: games
-      }
-    end
-
-    rounds
   end
 
-  def pairings_data_round(stage, players, view_decks, round, bracket_games)
+  def pairings_data_round(stage, players, view_decks, round)
     pairings = []
     pairings_reported = 0
     pairings_fields = %i[id table_number player1_id player2_id side intentional_draw
@@ -203,8 +230,6 @@ class RoundsController < ApplicationController
         end
       end
 
-      bracket_game = bracket_games&.find { |g| g[:table_number] == table_number }
-
       pairings << {
         id:,
         table_number:,
@@ -233,11 +258,7 @@ class RoundsController < ApplicationController
                                  score2, score2_corp, score2_runner),
         intentional_draw:,
         two_for_one:,
-        self_report: self_report_result,
-        round: bracket_game ? bracket_game[:round] : nil,
-        winner_game: bracket_game ? bracket_game[:winner_game] : nil,
-        loser_game: bracket_game ? bracket_game[:loser_game] : nil,
-        bracket_type: bracket_game ? bracket_game[:bracket_type] : nil
+        self_report: self_report_result
       }
     end
 
@@ -340,10 +361,10 @@ class RoundsController < ApplicationController
   end
 
   def bracket_games(stage)
-    return nil unless stage.elimination?
+    return nil unless stage[:is_elimination]
 
     begin
-      bracket = Bracket::Factory.bracket_for(stage.players.count, single_elim: stage.single_elim?)
+      bracket = Bracket::Factory.bracket_for(stage[:player_count], single_elim: stage[:format] == :single_elim)
     rescue RuntimeError
       return nil
     end

--- a/app/controllers/rounds_controller.rb
+++ b/app/controllers/rounds_controller.rb
@@ -235,7 +235,7 @@ class RoundsController < ApplicationController
         two_for_one:,
         self_report: self_report_result,
         round: bracket_game ? bracket_game[:round] : nil,
-        successor_game: bracket_game ? bracket_game[:successor_game] : nil,
+        winner_game: bracket_game ? bracket_game[:winner_game] : nil,
         bracket_type: bracket_game ? bracket_game[:bracket_type] : nil
       }
     end
@@ -353,7 +353,7 @@ class RoundsController < ApplicationController
         id: nil,
         table_number: game[:number],
         round: game[:round],
-        successor_game: game[:successor],
+        winner_game: game[:winner_game],
         bracket_type: game[:bracket_type].to_s
       }
     end

--- a/app/frontend/pairings/BracketDisplay.svelte
+++ b/app/frontend/pairings/BracketDisplay.svelte
@@ -74,7 +74,7 @@
   function keyFor(cIdx: number, rIdx: number, m: BracketMatch): string {
     return String(
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      m.id ?? m.table_number ?? m.successor_game ?? `${cIdx}-${rIdx}`,
+      m.id ?? m.table_number ?? m.winner_game ?? `${cIdx}-${rIdx}`,
     );
   }
 
@@ -120,7 +120,7 @@
   );
   const svgHeightTotal = $derived(svgHeightUpper + bracketGap + svgHeightLower);
 
-  // For connectors: map successor_game within same bracket
+  // For connectors: map winner_game within same bracket
   const connectorPath = $derived(
     (
       fromCol: number,
@@ -148,7 +148,7 @@
       col.forEach((m, rIdx) => {
         index.set(
           // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-          String(m.table_number ?? m.successor_game ?? `${cIdx}-${rIdx}`),
+          String(m.table_number ?? m.winner_game ?? `${cIdx}-${rIdx}`),
           { col: cIdx, row: rIdx },
         );
       });
@@ -164,11 +164,11 @@
       index: SvelteMap<string, { col: number; row: number }>,
       fromCol: number,
       fromRow: number,
-      successorGame: number,
+      winnerGame: number,
       yPos: number[][],
       colOffset = 0,
     ): string | null => {
-      const target = index.get(String(successorGame));
+      const target = index.get(String(winnerGame));
       if (!target) return null;
       return connectorPath(
         fromCol,
@@ -198,13 +198,13 @@
       for (let r = 0; r < cols[c].length; r++) {
         const match = cols[c][r];
         const predecessorYs: number[] = [];
-        // Find predecessors in any earlier column whose successor points to this match
+        // Find predecessors in any earlier column whose winner game points to this match
         if (match.table_number != null) {
           for (let pc = 0; pc < c; pc++) {
             for (let pr = 0; pr < cols[pc].length; pr++) {
               const prevMatch = cols[pc][pr];
-              if (prevMatch.successor_game != null) {
-                if (prevMatch.successor_game === match.table_number) {
+              if (prevMatch.winner_game != null) {
+                if (prevMatch.winner_game === match.table_number) {
                   predecessorYs.push(positions[pc][pr] + matchHeight / 2);
                 }
               }
@@ -239,14 +239,14 @@
           <!-- Connectors -->
           {#each upperCols as col, cIdx (cIdx)}
             {#each col as m, rIdx (keyFor(cIdx, rIdx, m))}
-              {#if m.successor_game != null}
-                {#if upperIndex.has(String(m.successor_game))}
+              {#if m.winner_game != null}
+                {#if upperIndex.has(String(m.winner_game))}
                   <path
                     d={connectorPathTo(
                       upperIndex,
                       cIdx,
                       rIdx,
-                      m.successor_game,
+                      m.winner_game,
                       upperY,
                     )}
                     stroke="#999"
@@ -280,14 +280,14 @@
         <g>
           {#each lowerCols as col, cIdx (cIdx)}
             {#each col as match, rIdx (keyFor(cIdx, rIdx, match))}
-              {#if match.successor_game != null}
-                {#if lowerIndex.has(String(match.successor_game))}
+              {#if match.winner_game != null}
+                {#if lowerIndex.has(String(match.winner_game))}
                   <path
                     d={connectorPathTo(
                       lowerIndex,
                       cIdx,
                       rIdx,
-                      match.successor_game,
+                      match.winner_game,
                       lowerY,
                       lowerColOffset,
                     )}

--- a/app/frontend/pairings/BracketPage.svelte
+++ b/app/frontend/pairings/BracketPage.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import BracketDisplay from "./BracketDisplay.svelte";
-  import type { PairingsData } from "./PairingsData";
-  import { loadPairings } from "./PairingsData";
+  import type { BracketData } from "./PairingsData";
+  import { loadBrackets } from "./PairingsData";
   import FontAwesomeIcon from "../widgets/FontAwesomeIcon.svelte";
   import { showIdentities } from "./ShowIdentities";
 
   export let tournamentId: number;
-  let data: PairingsData;
+  let data: BracketData;
 
   onMount(async () => {
-    data = await loadPairings(tournamentId);
+    data = await loadBrackets(tournamentId);
   });
 
   function toggleIdentities() {

--- a/app/frontend/pairings/PairingsData.ts
+++ b/app/frontend/pairings/PairingsData.ts
@@ -59,6 +59,7 @@ export interface Pairing {
   two_for_one: boolean;
   self_report: SelfReport | null;
   winner_game: number | null;
+  loser_game: number | null;
   bracket_type: string | null;
   ui_metadata: UiMetadata;
 }

--- a/app/frontend/pairings/PairingsData.ts
+++ b/app/frontend/pairings/PairingsData.ts
@@ -23,9 +23,7 @@ export async function loadPairings(
   return (await response.json()) as PairingsData;
 }
 
-export async function loadBrackets(
-  tournamentId: number,
-): Promise<BracketData> {
+export async function loadBrackets(tournamentId: number): Promise<BracketData> {
   const response = await fetch(
     Routes.brackets_tournament_rounds_path(tournamentId),
     {

--- a/app/frontend/pairings/PairingsData.ts
+++ b/app/frontend/pairings/PairingsData.ts
@@ -58,7 +58,7 @@ export interface Pairing {
   intentional_draw: boolean;
   two_for_one: boolean;
   self_report: SelfReport | null;
-  successor_game: number | null;
+  winner_game: number | null;
   bracket_type: string | null;
   ui_metadata: UiMetadata;
 }

--- a/app/frontend/pairings/PairingsData.ts
+++ b/app/frontend/pairings/PairingsData.ts
@@ -2,6 +2,7 @@ import type { Identity } from "../identities/Identity";
 
 declare const Routes: {
   pairings_data_tournament_rounds_path: (tournamentId: number) => string;
+  brackets_tournament_rounds_path: (tournamentId: number) => string;
   pairing_presets_tournament_round_pairing_path: (
     tournamentId: number,
     roundId: number,
@@ -22,9 +23,26 @@ export async function loadPairings(
   return (await response.json()) as PairingsData;
 }
 
+export async function loadBrackets(
+  tournamentId: number,
+): Promise<BracketData> {
+  const response = await fetch(
+    Routes.brackets_tournament_rounds_path(tournamentId),
+    {
+      method: "GET",
+    },
+  );
+
+  return (await response.json()) as BracketData;
+}
+
 export interface PairingsData {
   policy: TournamentPolicies;
   is_player_meeting: boolean;
+  stages: Stage[];
+}
+
+export interface BracketData {
   stages: Stage[];
 }
 

--- a/app/frontend/pairings/bracketTypes.ts
+++ b/app/frontend/pairings/bracketTypes.ts
@@ -11,7 +11,7 @@ export interface BracketMatch {
   id?: number;
   table_number?: number;
   table_label?: string;
-  successor_game?: number | null;
+  winner_game?: number | null;
   score_label?: string | null;
   player1?: BracketPlayer | null;
   player2?: BracketPlayer | null;

--- a/app/frontend/pairings/bracketTypes.ts
+++ b/app/frontend/pairings/bracketTypes.ts
@@ -12,6 +12,7 @@ export interface BracketMatch {
   table_number?: number;
   table_label?: string;
   winner_game?: number | null;
+  loser_game?: number | null;
   score_label?: string | null;
   player1?: BracketPlayer | null;
   player2?: BracketPlayer | null;

--- a/app/services/bracket/engine.rb
+++ b/app/services/bracket/engine.rb
@@ -16,6 +16,7 @@ module Bracket
             player2: p2,
             round: options[:round],
             winner_game: options[:winner_game],
+            loser_game: options[:loser_game],
             bracket_type: options[:bracket_type]
           }
         end

--- a/app/services/bracket/engine.rb
+++ b/app/services/bracket/engine.rb
@@ -15,7 +15,7 @@ module Bracket
             player1: p1,
             player2: p2,
             round: options[:round],
-            successor: options[:successor],
+            winner_game: options[:winner_game],
             bracket_type: options[:bracket_type]
           }
         end

--- a/app/services/bracket/single_elim_top16.rb
+++ b/app/services/bracket/single_elim_top16.rb
@@ -2,40 +2,40 @@
 
 module Bracket
   class SingleElimTop16 < Base
-    game 1, seed(1), seed(16), round: 1, successor: 9, bracket_type: :upper
-    game 2, seed(2), seed(15), round: 1, successor: 9, bracket_type: :upper
-    game 3, seed(3), seed(14), round: 1, successor: 10, bracket_type: :upper
-    game 4, seed(4), seed(13), round: 1, successor: 10, bracket_type: :upper
-    game 5, seed(5), seed(12), round: 1, successor: 11, bracket_type: :upper
-    game 6, seed(6), seed(11), round: 1, successor: 11, bracket_type: :upper
-    game 7, seed(7), seed(10), round: 1, successor: 12, bracket_type: :upper
-    game 8, seed(8), seed(9), round: 1, successor: 12, bracket_type: :upper
+    game 1, seed(1), seed(16), round: 1, winner_game: 9, bracket_type: :upper
+    game 2, seed(2), seed(15), round: 1, winner_game: 9, bracket_type: :upper
+    game 3, seed(3), seed(14), round: 1, winner_game: 10, bracket_type: :upper
+    game 4, seed(4), seed(13), round: 1, winner_game: 10, bracket_type: :upper
+    game 5, seed(5), seed(12), round: 1, winner_game: 11, bracket_type: :upper
+    game 6, seed(6), seed(11), round: 1, winner_game: 11, bracket_type: :upper
+    game 7, seed(7), seed(10), round: 1, winner_game: 12, bracket_type: :upper
+    game 8, seed(8), seed(9), round: 1, winner_game: 12, bracket_type: :upper
 
     game 9,
          seed_of([winner(1), winner(2), winner(3), winner(4), winner(5), winner(6), winner(7), winner(8)], 1),
          seed_of([winner(1), winner(2), winner(3), winner(4), winner(5), winner(6), winner(7), winner(8)], 8),
-         round: 2, successor: 13, bracket_type: :upper
+         round: 2, winner_game: 13, bracket_type: :upper
     game 10,
          seed_of([winner(1), winner(2), winner(3), winner(4), winner(5), winner(6), winner(7), winner(8)], 2),
          seed_of([winner(1), winner(2), winner(3), winner(4), winner(5), winner(6), winner(7), winner(8)], 7),
-         round: 2, successor: 13, bracket_type: :upper
+         round: 2, winner_game: 13, bracket_type: :upper
     game 11,
          seed_of([winner(1), winner(2), winner(3), winner(4), winner(5), winner(6), winner(7), winner(8)], 3),
          seed_of([winner(1), winner(2), winner(3), winner(4), winner(5), winner(6), winner(7), winner(8)], 6),
-         round: 2, successor: 14, bracket_type: :upper
+         round: 2, winner_game: 14, bracket_type: :upper
     game 12,
          seed_of([winner(1), winner(2), winner(3), winner(4), winner(5), winner(6), winner(7), winner(8)], 4),
          seed_of([winner(1), winner(2), winner(3), winner(4), winner(5), winner(6), winner(7), winner(8)], 5),
-         round: 2, successor: 14, bracket_type: :upper
+         round: 2, winner_game: 14, bracket_type: :upper
 
     game 13,
          seed_of([winner(9), winner(10), winner(11), winner(12)], 1),
          seed_of([winner(9), winner(10), winner(11), winner(12)], 4),
-         round: 3, successor: 15, bracket_type: :upper
+         round: 3, winner_game: 15, bracket_type: :upper
     game 14,
          seed_of([winner(9), winner(10), winner(11), winner(12)], 2),
          seed_of([winner(9), winner(10), winner(11), winner(12)], 3),
-         round: 3, successor: 15, bracket_type: :upper
+         round: 3, winner_game: 15, bracket_type: :upper
 
     game 15, seed_of([winner(13), winner(14)], 1), seed_of([winner(13), winner(14)], 2), round: 4, bracket_type: :upper
 

--- a/app/services/bracket/single_elim_top3.rb
+++ b/app/services/bracket/single_elim_top3.rb
@@ -2,7 +2,7 @@
 
 module Bracket
   class SingleElimTop3 < Base
-    game 1, seed(2), seed(3), round: 1, successor: 2, bracket_type: :upper
+    game 1, seed(2), seed(3), round: 1, winner_game: 2, bracket_type: :upper
 
     game 2, seed(1), winner(1), round: 2, bracket_type: :upper
 

--- a/app/services/bracket/single_elim_top4.rb
+++ b/app/services/bracket/single_elim_top4.rb
@@ -2,8 +2,8 @@
 
 module Bracket
   class SingleElimTop4 < Base
-    game 1, seed(1), seed(4), round: 1, successor: 3, bracket_type: :upper
-    game 2, seed(2), seed(3), round: 1, successor: 3, bracket_type: :upper
+    game 1, seed(1), seed(4), round: 1, winner_game: 3, bracket_type: :upper
+    game 2, seed(2), seed(3), round: 1, winner_game: 3, bracket_type: :upper
 
     game 3, seed_of([winner(1), winner(2)], 1), seed_of([winner(1), winner(2)], 2), round: 2, bracket_type: :upper
 

--- a/app/services/bracket/single_elim_top8.rb
+++ b/app/services/bracket/single_elim_top8.rb
@@ -2,15 +2,15 @@
 
 module Bracket
   class SingleElimTop8 < Base
-    game 1, seed(1), seed(8), round: 1, successor: 5, bracket_type: :upper
-    game 2, seed(2), seed(7), round: 1, successor: 5, bracket_type: :upper
-    game 3, seed(3), seed(6), round: 1, successor: 6, bracket_type: :upper
-    game 4, seed(4), seed(5), round: 1, successor: 6, bracket_type: :upper
+    game 1, seed(1), seed(8), round: 1, winner_game: 5, bracket_type: :upper
+    game 2, seed(2), seed(7), round: 1, winner_game: 5, bracket_type: :upper
+    game 3, seed(3), seed(6), round: 1, winner_game: 6, bracket_type: :upper
+    game 4, seed(4), seed(5), round: 1, winner_game: 6, bracket_type: :upper
 
     game 5, seed_of([winner(1), winner(2), winner(3), winner(4)], 1),
-         seed_of([winner(1), winner(2), winner(3), winner(4)], 4), round: 2, successor: 7, bracket_type: :upper
+         seed_of([winner(1), winner(2), winner(3), winner(4)], 4), round: 2, winner_game: 7, bracket_type: :upper
     game 6, seed_of([winner(1), winner(2), winner(3), winner(4)], 2),
-         seed_of([winner(1), winner(2), winner(3), winner(4)], 3), round: 2, successor: 7, bracket_type: :upper
+         seed_of([winner(1), winner(2), winner(3), winner(4)], 3), round: 2, winner_game: 7, bracket_type: :upper
 
     game 7, seed_of([winner(5), winner(6)], 1), seed_of([winner(5), winner(6)], 2), round: 3, bracket_type: :upper
 

--- a/app/services/bracket/top16.rb
+++ b/app/services/bracket/top16.rb
@@ -2,34 +2,34 @@
 
 module Bracket
   class Top16 < Base
-    game 1, seed(1), seed(16), round: 1, winner_game: 13, bracket_type: :upper
-    game 2, seed(8), seed(9), round: 1, winner_game: 13, bracket_type: :upper
-    game 3, seed(5), seed(12), round: 1, winner_game: 14, bracket_type: :upper
-    game 4, seed(4), seed(13), round: 1, winner_game: 14, bracket_type: :upper
-    game 5, seed(3), seed(14), round: 1, winner_game: 15, bracket_type: :upper
-    game 6, seed(6), seed(11), round: 1, winner_game: 15, bracket_type: :upper
-    game 7, seed(7), seed(10), round: 1, winner_game: 16, bracket_type: :upper
-    game 8, seed(2), seed(15), round: 1, winner_game: 16, bracket_type: :upper
+    game 1, seed(1), seed(16), round: 1, winner_game: 13, loser_game: 9, bracket_type: :upper
+    game 2, seed(8), seed(9), round: 1, winner_game: 13, loser_game: 9, bracket_type: :upper
+    game 3, seed(5), seed(12), round: 1, winner_game: 14, loser_game: 10, bracket_type: :upper
+    game 4, seed(4), seed(13), round: 1, winner_game: 14, loser_game: 10, bracket_type: :upper
+    game 5, seed(3), seed(14), round: 1, winner_game: 15, loser_game: 11, bracket_type: :upper
+    game 6, seed(6), seed(11), round: 1, winner_game: 15, loser_game: 11, bracket_type: :upper
+    game 7, seed(7), seed(10), round: 1, winner_game: 16, loser_game: 12, bracket_type: :upper
+    game 8, seed(2), seed(15), round: 1, winner_game: 16, loser_game: 12, bracket_type: :upper
 
     game 9, loser(1), loser(2), round: 2, winner_game: 17, bracket_type: :lower
     game 10, loser(3), loser(4), round: 2, winner_game: 18, bracket_type: :lower
     game 11, loser(5), loser(6), round: 2, winner_game: 19, bracket_type: :lower
     game 12, loser(7), loser(8), round: 2, winner_game: 20, bracket_type: :lower
-    game 13, winner(1), winner(2), round: 2, winner_game: 21, bracket_type: :upper
-    game 14, winner(3), winner(4), round: 2, winner_game: 21, bracket_type: :upper
-    game 15, winner(5), winner(6), round: 2, winner_game: 22, bracket_type: :upper
-    game 16, winner(7), winner(8), round: 2, winner_game: 22, bracket_type: :upper
+    game 13, winner(1), winner(2), round: 2, winner_game: 21, loser_game: 20, bracket_type: :upper
+    game 14, winner(3), winner(4), round: 2, winner_game: 21, loser_game: 19, bracket_type: :upper
+    game 15, winner(5), winner(6), round: 2, winner_game: 22, loser_game: 18, bracket_type: :upper
+    game 16, winner(7), winner(8), round: 2, winner_game: 22, loser_game: 17, bracket_type: :upper
 
     game 17, loser(16), winner(9), round: 3, winner_game: 23, bracket_type: :lower
     game 18, loser(15), winner(10), round: 3, winner_game: 23, bracket_type: :lower
     game 19, loser(14), winner(11), round: 3, winner_game: 24, bracket_type: :lower
     game 20, loser(13), winner(12), round: 3, winner_game: 24, bracket_type: :lower
-    game 21, winner(13), winner(14), round: 3, winner_game: 27, bracket_type: :upper
-    game 22, winner(15), winner(16), round: 3, winner_game: 27, bracket_type: :upper
+    game 21, winner(13), winner(14), round: 3, winner_game: 27, loser_game: 25, bracket_type: :upper
+    game 22, winner(15), winner(16), round: 3, winner_game: 27, loser_game: 26, bracket_type: :upper
 
     game 23, winner(17), winner(18), round: 4, winner_game: 25, bracket_type: :lower
     game 24, winner(19), winner(20), round: 4, winner_game: 26, bracket_type: :lower
-    game 27, winner(21), winner(22), round: 4, winner_game: 30, bracket_type: :upper
+    game 27, winner(21), winner(22), round: 4, winner_game: 30, loser_game: 29, bracket_type: :upper
 
     game 25, loser(21), winner(23), round: 5, winner_game: 28, bracket_type: :lower
     game 26, winner(24), loser(22), round: 5, winner_game: 28, bracket_type: :lower
@@ -38,7 +38,7 @@ module Bracket
 
     game 29, loser(27), winner(28), round: 7, winner_game: 30, bracket_type: :lower
 
-    game 30, winner(27), winner(29), round: 8, winner_game: 31, bracket_type: :upper
+    game 30, winner(27), winner(29), round: 8, winner_game: 31, loser_game: 31, bracket_type: :upper
 
     game 31, winner(30), loser(30), round: 9, bracket_type: :upper
 

--- a/app/services/bracket/top16.rb
+++ b/app/services/bracket/top16.rb
@@ -2,43 +2,43 @@
 
 module Bracket
   class Top16 < Base
-    game 1, seed(1), seed(16), round: 1, successor: 13, bracket_type: :upper
-    game 2, seed(8), seed(9), round: 1, successor: 13, bracket_type: :upper
-    game 3, seed(5), seed(12), round: 1, successor: 14, bracket_type: :upper
-    game 4, seed(4), seed(13), round: 1, successor: 14, bracket_type: :upper
-    game 5, seed(3), seed(14), round: 1, successor: 15, bracket_type: :upper
-    game 6, seed(6), seed(11), round: 1, successor: 15, bracket_type: :upper
-    game 7, seed(7), seed(10), round: 1, successor: 16, bracket_type: :upper
-    game 8, seed(2), seed(15), round: 1, successor: 16, bracket_type: :upper
+    game 1, seed(1), seed(16), round: 1, winner_game: 13, bracket_type: :upper
+    game 2, seed(8), seed(9), round: 1, winner_game: 13, bracket_type: :upper
+    game 3, seed(5), seed(12), round: 1, winner_game: 14, bracket_type: :upper
+    game 4, seed(4), seed(13), round: 1, winner_game: 14, bracket_type: :upper
+    game 5, seed(3), seed(14), round: 1, winner_game: 15, bracket_type: :upper
+    game 6, seed(6), seed(11), round: 1, winner_game: 15, bracket_type: :upper
+    game 7, seed(7), seed(10), round: 1, winner_game: 16, bracket_type: :upper
+    game 8, seed(2), seed(15), round: 1, winner_game: 16, bracket_type: :upper
 
-    game 9, loser(1), loser(2), round: 2, successor: 17, bracket_type: :lower
-    game 10, loser(3), loser(4), round: 2, successor: 18, bracket_type: :lower
-    game 11, loser(5), loser(6), round: 2, successor: 19, bracket_type: :lower
-    game 12, loser(7), loser(8), round: 2, successor: 20, bracket_type: :lower
-    game 13, winner(1), winner(2), round: 2, successor: 21, bracket_type: :upper
-    game 14, winner(3), winner(4), round: 2, successor: 21, bracket_type: :upper
-    game 15, winner(5), winner(6), round: 2, successor: 22, bracket_type: :upper
-    game 16, winner(7), winner(8), round: 2, successor: 22, bracket_type: :upper
+    game 9, loser(1), loser(2), round: 2, winner_game: 17, bracket_type: :lower
+    game 10, loser(3), loser(4), round: 2, winner_game: 18, bracket_type: :lower
+    game 11, loser(5), loser(6), round: 2, winner_game: 19, bracket_type: :lower
+    game 12, loser(7), loser(8), round: 2, winner_game: 20, bracket_type: :lower
+    game 13, winner(1), winner(2), round: 2, winner_game: 21, bracket_type: :upper
+    game 14, winner(3), winner(4), round: 2, winner_game: 21, bracket_type: :upper
+    game 15, winner(5), winner(6), round: 2, winner_game: 22, bracket_type: :upper
+    game 16, winner(7), winner(8), round: 2, winner_game: 22, bracket_type: :upper
 
-    game 17, loser(16), winner(9), round: 3, successor: 23, bracket_type: :lower
-    game 18, loser(15), winner(10), round: 3, successor: 23, bracket_type: :lower
-    game 19, loser(14), winner(11), round: 3, successor: 24, bracket_type: :lower
-    game 20, loser(13), winner(12), round: 3, successor: 24, bracket_type: :lower
-    game 21, winner(13), winner(14), round: 3, successor: 27, bracket_type: :upper
-    game 22, winner(15), winner(16), round: 3, successor: 27, bracket_type: :upper
+    game 17, loser(16), winner(9), round: 3, winner_game: 23, bracket_type: :lower
+    game 18, loser(15), winner(10), round: 3, winner_game: 23, bracket_type: :lower
+    game 19, loser(14), winner(11), round: 3, winner_game: 24, bracket_type: :lower
+    game 20, loser(13), winner(12), round: 3, winner_game: 24, bracket_type: :lower
+    game 21, winner(13), winner(14), round: 3, winner_game: 27, bracket_type: :upper
+    game 22, winner(15), winner(16), round: 3, winner_game: 27, bracket_type: :upper
 
-    game 23, winner(17), winner(18), round: 4, successor: 25, bracket_type: :lower
-    game 24, winner(19), winner(20), round: 4, successor: 26, bracket_type: :lower
-    game 27, winner(21), winner(22), round: 4, successor: 30, bracket_type: :upper
+    game 23, winner(17), winner(18), round: 4, winner_game: 25, bracket_type: :lower
+    game 24, winner(19), winner(20), round: 4, winner_game: 26, bracket_type: :lower
+    game 27, winner(21), winner(22), round: 4, winner_game: 30, bracket_type: :upper
 
-    game 25, loser(21), winner(23), round: 5, successor: 28, bracket_type: :lower
-    game 26, winner(24), loser(22), round: 5, successor: 28, bracket_type: :lower
+    game 25, loser(21), winner(23), round: 5, winner_game: 28, bracket_type: :lower
+    game 26, winner(24), loser(22), round: 5, winner_game: 28, bracket_type: :lower
 
-    game 28, winner(25), winner(26), round: 6, successor: 29, bracket_type: :lower
+    game 28, winner(25), winner(26), round: 6, winner_game: 29, bracket_type: :lower
 
-    game 29, loser(27), winner(28), round: 7, successor: 30, bracket_type: :lower
+    game 29, loser(27), winner(28), round: 7, winner_game: 30, bracket_type: :lower
 
-    game 30, winner(27), winner(29), round: 8, successor: 31, bracket_type: :upper
+    game 30, winner(27), winner(29), round: 8, winner_game: 31, bracket_type: :upper
 
     game 31, winner(30), loser(30), round: 9, bracket_type: :upper
 

--- a/app/services/bracket/top4.rb
+++ b/app/services/bracket/top4.rb
@@ -2,15 +2,15 @@
 
 module Bracket
   class Top4 < Base
-    game 1, seed(1), seed(4), round: 1, successor: 3, bracket_type: :upper
-    game 2, seed(2), seed(3), round: 1, successor: 3, bracket_type: :upper
+    game 1, seed(1), seed(4), round: 1, winner_game: 3, loser_game: 4, bracket_type: :upper
+    game 2, seed(2), seed(3), round: 1, winner_game: 3, loser_game: 4, bracket_type: :upper
 
-    game 3, winner(1), winner(2), round: 2, successor: 6, bracket_type: :upper
-    game 4, loser(1), loser(2), round: 2, successor: 5, bracket_type: :lower
+    game 3, winner(1), winner(2), round: 2, winner_game: 6, loser_game: 5, bracket_type: :upper
+    game 4, loser(1), loser(2), round: 2, winner_game: 5, bracket_type: :lower
 
-    game 5, loser(3), winner(4), round: 3, successor: 6, bracket_type: :lower
+    game 5, loser(3), winner(4), round: 3, winner_game: 6, bracket_type: :lower
 
-    game 6, winner(3), winner(5), round: 4, successor: 7, bracket_type: :upper
+    game 6, winner(3), winner(5), round: 4, winner_game: 7, loser_game: 7, bracket_type: :upper
 
     game 7, winner(6), loser(6), round: 5, bracket_type: :upper
 

--- a/app/services/bracket/top8.rb
+++ b/app/services/bracket/top8.rb
@@ -2,25 +2,25 @@
 
 module Bracket
   class Top8 < Base
-    game 1, seed(1), seed(8), round: 1, successor: 5, bracket_type: :upper
-    game 2, seed(4), seed(5), round: 1, successor: 5, bracket_type: :upper
-    game 3, seed(2), seed(7), round: 1, successor: 6, bracket_type: :upper
-    game 4, seed(3), seed(6), round: 1, successor: 6, bracket_type: :upper
+    game 1, seed(1), seed(8), round: 1, winner_game: 5, bracket_type: :upper
+    game 2, seed(4), seed(5), round: 1, winner_game: 5, bracket_type: :upper
+    game 3, seed(2), seed(7), round: 1, winner_game: 6, bracket_type: :upper
+    game 4, seed(3), seed(6), round: 1, winner_game: 6, bracket_type: :upper
 
-    game 5, winner(1), winner(2), round: 2, successor: 9, bracket_type: :upper
-    game 6, winner(3), winner(4), round: 2, successor: 9, bracket_type: :upper
-    game 7, loser(1), loser(2), round: 2, successor: 10, bracket_type: :lower
-    game 8, loser(3), loser(4), round: 2, successor: 11, bracket_type: :lower
+    game 5, winner(1), winner(2), round: 2, winner_game: 9, bracket_type: :upper
+    game 6, winner(3), winner(4), round: 2, winner_game: 9, bracket_type: :upper
+    game 7, loser(1), loser(2), round: 2, winner_game: 10, bracket_type: :lower
+    game 8, loser(3), loser(4), round: 2, winner_game: 11, bracket_type: :lower
 
-    game 9, winner(5), winner(6), round: 3, successor: 14, bracket_type: :upper
-    game 10, loser(6), winner(7), round: 3, successor: 12, bracket_type: :lower
-    game 11, winner(8), loser(5), round: 3, successor: 12, bracket_type: :lower
+    game 9, winner(5), winner(6), round: 3, winner_game: 14, bracket_type: :upper
+    game 10, loser(6), winner(7), round: 3, winner_game: 12, bracket_type: :lower
+    game 11, winner(8), loser(5), round: 3, winner_game: 12, bracket_type: :lower
 
-    game 12, winner(10), winner(11), round: 4, successor: 13, bracket_type: :lower
+    game 12, winner(10), winner(11), round: 4, winner_game: 13, bracket_type: :lower
 
-    game 13, loser(9), winner(12), round: 5, successor: 14, bracket_type: :lower
+    game 13, loser(9), winner(12), round: 5, winner_game: 14, bracket_type: :lower
 
-    game 14, winner(9), winner(13), round: 6, successor: 15, bracket_type: :upper
+    game 14, winner(9), winner(13), round: 6, winner_game: 15, bracket_type: :upper
 
     game 15, winner(14), loser(14), round: 7, bracket_type: :upper
 

--- a/app/services/bracket/top8.rb
+++ b/app/services/bracket/top8.rb
@@ -2,17 +2,17 @@
 
 module Bracket
   class Top8 < Base
-    game 1, seed(1), seed(8), round: 1, winner_game: 5, bracket_type: :upper
-    game 2, seed(4), seed(5), round: 1, winner_game: 5, bracket_type: :upper
-    game 3, seed(2), seed(7), round: 1, winner_game: 6, bracket_type: :upper
-    game 4, seed(3), seed(6), round: 1, winner_game: 6, bracket_type: :upper
+    game 1, seed(1), seed(8), round: 1, winner_game: 5, loser_game: 7, bracket_type: :upper
+    game 2, seed(4), seed(5), round: 1, winner_game: 5, loser_game: 7, bracket_type: :upper
+    game 3, seed(2), seed(7), round: 1, winner_game: 6, loser_game: 8, bracket_type: :upper
+    game 4, seed(3), seed(6), round: 1, winner_game: 6, loser_game: 8, bracket_type: :upper
 
-    game 5, winner(1), winner(2), round: 2, winner_game: 9, bracket_type: :upper
-    game 6, winner(3), winner(4), round: 2, winner_game: 9, bracket_type: :upper
+    game 5, winner(1), winner(2), round: 2, winner_game: 9, loser_game: 11, bracket_type: :upper
+    game 6, winner(3), winner(4), round: 2, winner_game: 9, loser_game: 10, bracket_type: :upper
     game 7, loser(1), loser(2), round: 2, winner_game: 10, bracket_type: :lower
     game 8, loser(3), loser(4), round: 2, winner_game: 11, bracket_type: :lower
 
-    game 9, winner(5), winner(6), round: 3, winner_game: 14, bracket_type: :upper
+    game 9, winner(5), winner(6), round: 3, winner_game: 14, loser_game: 13, bracket_type: :upper
     game 10, loser(6), winner(7), round: 3, winner_game: 12, bracket_type: :lower
     game 11, winner(8), loser(5), round: 3, winner_game: 12, bracket_type: :lower
 
@@ -20,7 +20,7 @@ module Bracket
 
     game 13, loser(9), winner(12), round: 5, winner_game: 14, bracket_type: :lower
 
-    game 14, winner(9), winner(13), round: 6, winner_game: 15, bracket_type: :upper
+    game 14, winner(9), winner(13), round: 6, winner_game: 15, loser_game: 15, bracket_type: :upper
 
     game 15, winner(14), loser(14), round: 7, bracket_type: :upper
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
       patch :update_timer, on: :member
       get :view_pairings, on: :collection
       get :pairings_data, on: :collection
+      get :brackets, on: :collection
     end
     get :bracket, on: :member
     resources :stages, only: %i[show create update destroy] do

--- a/spec/requests/rounds_controller_spec.rb
+++ b/spec/requests/rounds_controller_spec.rb
@@ -69,16 +69,14 @@ RSpec.describe RoundsController do
                              'policy' => { 'view_decks' => false, 'self_report' => false },
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => ' - ', 'two_for_one' => false,
-                             'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil,
-                             'round' => nil, 'winner_game' => nil, 'loser_game' => nil, 'bracket_type' => nil },
+                             'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil },
                            { 'intentional_draw' => false,
                              'player1' => player_with_no_ids('Alice (she/her)'),
                              'player2' => bye_player,
                              'policy' => { 'view_decks' => false, 'self_report' => false },
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => '6 - 0', 'two_for_one' => false,
-                             'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil,
-                             'round' => nil, 'winner_game' => nil, 'loser_game' => nil, 'bracket_type' => nil }
+                             'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil }
                          ], 'pairings_reported' => 1
                        }
                      ]
@@ -107,8 +105,7 @@ RSpec.describe RoundsController do
                              }, # sees player view as a player
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => ' - ', 'two_for_one' => false,
-                             'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil,
-                             'round' => nil, 'winner_game' => nil, 'loser_game' => nil, 'bracket_type' => nil },
+                             'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil },
                            { 'intentional_draw' => false,
                              'player1' => player_with_no_ids('Alice (she/her)'),
                              'player2' => bye_player,
@@ -118,8 +115,7 @@ RSpec.describe RoundsController do
                              }, # sees player view as a player
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => '6 - 0', 'two_for_one' => false,
-                             'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil,
-                             'round' => nil, 'winner_game' => nil, 'loser_game' => nil, 'bracket_type' => nil }
+                             'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil }
                          ], 'pairings_reported' => 1
                        }
                      ]
@@ -154,16 +150,64 @@ RSpec.describe RoundsController do
                                'policy' => { 'view_decks' => false, 'self_report' => false },
                                'ui_metadata' => { 'row_highlighted' => false },
                                'score_label' => ' - ', 'two_for_one' => false,
-                               'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil,
-                               'round' => nil, 'winner_game' => nil, 'loser_game' => nil, 'bracket_type' => nil },
+                               'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil },
                              { 'intentional_draw' => false,
                                'player1' => player_with_no_ids('Alice (she/her)'),
                                'player2' => bye_player,
                                'policy' => { 'view_decks' => false, 'self_report' => false },
                                'ui_metadata' => { 'row_highlighted' => false },
                                'score_label' => '6 - 0', 'two_for_one' => false,
-                               'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil,
-                               'round' => nil, 'winner_game' => nil, 'loser_game' => nil, 'bracket_type' => nil }
+                               'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil }
+                           ], 'pairings_reported' => 1
+                         }
+                       ]
+                     ),
+                     cut_stage_with_rounds(
+                       [
+                         {
+                           'number' => 1,
+                           'pairings' => [
+                             { 'intentional_draw' => false,
+                               'player1' => player_with_no_ids('Bob (he/him)'),
+                               'player2' => player_with_no_ids('Charlie (she/her)'),
+                               'policy' => { 'view_decks' => false, 'self_report' => false },
+                               'ui_metadata' => { 'row_highlighted' => false },
+                               'score_label' => ' - ', 'two_for_one' => false,
+                               'table_label' => 'Game 1', 'table_number' => 1, 'self_report' => nil }
+                           ],
+                           'pairings_reported' => 0
+                         }
+                       ]
+                     )
+                   ]
+                 })
+      end
+
+      it 'displays bracket info' do
+        sign_in nil
+        get brackets_tournament_rounds_path(tournament)
+        expect(compare_body(response))
+          .to eq({
+                   'stages' => [
+                     swiss_stage_with_rounds(
+                       [
+                         {
+                           'number' => 1,
+                           'pairings' => [
+                             { 'intentional_draw' => false,
+                               'player1' => player_with_no_ids('Charlie (she/her)'),
+                               'player2' => player_with_no_ids('Bob (he/him)'),
+                               'policy' => { 'view_decks' => false, 'self_report' => false },
+                               'ui_metadata' => { 'row_highlighted' => false },
+                               'score_label' => ' - ', 'two_for_one' => false,
+                               'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil },
+                             { 'intentional_draw' => false,
+                               'player1' => player_with_no_ids('Alice (she/her)'),
+                               'player2' => bye_player,
+                               'policy' => { 'view_decks' => false, 'self_report' => false },
+                               'ui_metadata' => { 'row_highlighted' => false },
+                               'score_label' => '6 - 0', 'two_for_one' => false,
+                               'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil }
                            ], 'pairings_reported' => 1
                          }
                        ]
@@ -226,16 +270,14 @@ RSpec.describe RoundsController do
                              'policy' => { 'view_decks' => false, 'self_report' => false },
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => '3 - 0 (C)', 'two_for_one' => false,
-                             'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil,
-                             'round' => nil, 'winner_game' => nil, 'loser_game' => nil, 'bracket_type' => nil },
+                             'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil },
                            { 'intentional_draw' => false,
                              'player1' => player_with_no_ids('Alice (she/her)'),
                              'player2' => bye_player,
                              'policy' => { 'view_decks' => false, 'self_report' => false },
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => '6 - 0', 'two_for_one' => false,
-                             'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil,
-                             'round' => nil, 'winner_game' => nil, 'loser_game' => nil, 'bracket_type' => nil }
+                             'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil }
                          ], 'pairings_reported' => 2
                        }
                      ]
@@ -274,16 +316,14 @@ RSpec.describe RoundsController do
                              'policy' => { 'view_decks' => false, 'self_report' => false },
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => '0 - 3 (R)', 'two_for_one' => false,
-                             'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil,
-                             'round' => nil, 'winner_game' => nil, 'loser_game' => nil, 'bracket_type' => nil },
+                             'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil },
                            { 'intentional_draw' => false,
                              'player1' => player_with_no_ids('Alice (she/her)'),
                              'player2' => bye_player,
                              'policy' => { 'view_decks' => false, 'self_report' => false },
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => '6 - 0', 'two_for_one' => false,
-                             'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil,
-                             'round' => nil, 'winner_game' => nil, 'loser_game' => nil, 'bracket_type' => nil }
+                             'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil }
                          ], 'pairings_reported' => 2
                        }
                      ]
@@ -331,7 +371,8 @@ RSpec.describe RoundsController do
       'format' => 'swiss',
       'is_single_sided' => false,
       'is_elimination' => false,
-      'rounds' => rounds
+      'rounds' => rounds,
+      'player_count' => 3
     }
   end
 
@@ -341,7 +382,8 @@ RSpec.describe RoundsController do
       'format' => 'double_elim',
       'is_single_sided' => true,
       'is_elimination' => true,
-      'rounds' => rounds
+      'rounds' => rounds,
+      'player_count' => 3
     }
   end
 end

--- a/spec/requests/rounds_controller_spec.rb
+++ b/spec/requests/rounds_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe RoundsController do
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => ' - ', 'two_for_one' => false,
                              'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil,
-                             'round' => nil, 'winner_game' => nil, 'bracket_type' => nil },
+                             'round' => nil, 'winner_game' => nil, 'loser_game' => nil, 'bracket_type' => nil },
                            { 'intentional_draw' => false,
                              'player1' => player_with_no_ids('Alice (she/her)'),
                              'player2' => bye_player,
@@ -78,7 +78,7 @@ RSpec.describe RoundsController do
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => '6 - 0', 'two_for_one' => false,
                              'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil,
-                             'round' => nil, 'winner_game' => nil, 'bracket_type' => nil }
+                             'round' => nil, 'winner_game' => nil, 'loser_game' => nil, 'bracket_type' => nil }
                          ], 'pairings_reported' => 1
                        }
                      ]
@@ -108,7 +108,7 @@ RSpec.describe RoundsController do
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => ' - ', 'two_for_one' => false,
                              'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil,
-                             'round' => nil, 'winner_game' => nil, 'bracket_type' => nil },
+                             'round' => nil, 'winner_game' => nil, 'loser_game' => nil, 'bracket_type' => nil },
                            { 'intentional_draw' => false,
                              'player1' => player_with_no_ids('Alice (she/her)'),
                              'player2' => bye_player,
@@ -119,7 +119,7 @@ RSpec.describe RoundsController do
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => '6 - 0', 'two_for_one' => false,
                              'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil,
-                             'round' => nil, 'winner_game' => nil, 'bracket_type' => nil }
+                             'round' => nil, 'winner_game' => nil, 'loser_game' => nil, 'bracket_type' => nil }
                          ], 'pairings_reported' => 1
                        }
                      ]
@@ -155,7 +155,7 @@ RSpec.describe RoundsController do
                                'ui_metadata' => { 'row_highlighted' => false },
                                'score_label' => ' - ', 'two_for_one' => false,
                                'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil,
-                               'round' => nil, 'winner_game' => nil, 'bracket_type' => nil },
+                               'round' => nil, 'winner_game' => nil, 'loser_game' => nil, 'bracket_type' => nil },
                              { 'intentional_draw' => false,
                                'player1' => player_with_no_ids('Alice (she/her)'),
                                'player2' => bye_player,
@@ -163,7 +163,7 @@ RSpec.describe RoundsController do
                                'ui_metadata' => { 'row_highlighted' => false },
                                'score_label' => '6 - 0', 'two_for_one' => false,
                                'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil,
-                               'round' => nil, 'winner_game' => nil, 'bracket_type' => nil }
+                               'round' => nil, 'winner_game' => nil, 'loser_game' => nil, 'bracket_type' => nil }
                            ], 'pairings_reported' => 1
                          }
                        ]
@@ -180,14 +180,14 @@ RSpec.describe RoundsController do
                                'ui_metadata' => { 'row_highlighted' => false },
                                'score_label' => ' - ', 'two_for_one' => false,
                                'table_label' => 'Game 1', 'table_number' => 1, 'self_report' => nil,
-                               'round' => 1, 'winner_game' => 2, 'bracket_type' => 'upper' }
+                               'round' => 1, 'winner_game' => 2, 'loser_game' => nil, 'bracket_type' => 'upper' }
                            ],
                            'pairings_reported' => 0
                          },
                          {
                            'number' => 2,
                            'pairings' => [
-                             { 'table_number' => 2, 'round' => 2, 'winner_game' => nil,
+                             { 'table_number' => 2, 'round' => 2, 'winner_game' => nil, 'loser_game' => nil,
                                'bracket_type' => 'upper' }
                            ]
                          }
@@ -227,7 +227,7 @@ RSpec.describe RoundsController do
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => '3 - 0 (C)', 'two_for_one' => false,
                              'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil,
-                             'round' => nil, 'winner_game' => nil, 'bracket_type' => nil },
+                             'round' => nil, 'winner_game' => nil, 'loser_game' => nil, 'bracket_type' => nil },
                            { 'intentional_draw' => false,
                              'player1' => player_with_no_ids('Alice (she/her)'),
                              'player2' => bye_player,
@@ -235,7 +235,7 @@ RSpec.describe RoundsController do
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => '6 - 0', 'two_for_one' => false,
                              'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil,
-                             'round' => nil, 'winner_game' => nil, 'bracket_type' => nil }
+                             'round' => nil, 'winner_game' => nil, 'loser_game' => nil, 'bracket_type' => nil }
                          ], 'pairings_reported' => 2
                        }
                      ]
@@ -275,7 +275,7 @@ RSpec.describe RoundsController do
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => '0 - 3 (R)', 'two_for_one' => false,
                              'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil,
-                             'round' => nil, 'winner_game' => nil, 'bracket_type' => nil },
+                             'round' => nil, 'winner_game' => nil, 'loser_game' => nil, 'bracket_type' => nil },
                            { 'intentional_draw' => false,
                              'player1' => player_with_no_ids('Alice (she/her)'),
                              'player2' => bye_player,
@@ -283,7 +283,7 @@ RSpec.describe RoundsController do
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => '6 - 0', 'two_for_one' => false,
                              'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil,
-                             'round' => nil, 'winner_game' => nil, 'bracket_type' => nil }
+                             'round' => nil, 'winner_game' => nil, 'loser_game' => nil, 'bracket_type' => nil }
                          ], 'pairings_reported' => 2
                        }
                      ]

--- a/spec/requests/rounds_controller_spec.rb
+++ b/spec/requests/rounds_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe RoundsController do
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => ' - ', 'two_for_one' => false,
                              'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil,
-                             'round' => nil, 'successor_game' => nil, 'bracket_type' => nil },
+                             'round' => nil, 'winner_game' => nil, 'bracket_type' => nil },
                            { 'intentional_draw' => false,
                              'player1' => player_with_no_ids('Alice (she/her)'),
                              'player2' => bye_player,
@@ -78,7 +78,7 @@ RSpec.describe RoundsController do
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => '6 - 0', 'two_for_one' => false,
                              'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil,
-                             'round' => nil, 'successor_game' => nil, 'bracket_type' => nil }
+                             'round' => nil, 'winner_game' => nil, 'bracket_type' => nil }
                          ], 'pairings_reported' => 1
                        }
                      ]
@@ -108,7 +108,7 @@ RSpec.describe RoundsController do
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => ' - ', 'two_for_one' => false,
                              'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil,
-                             'round' => nil, 'successor_game' => nil, 'bracket_type' => nil },
+                             'round' => nil, 'winner_game' => nil, 'bracket_type' => nil },
                            { 'intentional_draw' => false,
                              'player1' => player_with_no_ids('Alice (she/her)'),
                              'player2' => bye_player,
@@ -119,7 +119,7 @@ RSpec.describe RoundsController do
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => '6 - 0', 'two_for_one' => false,
                              'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil,
-                             'round' => nil, 'successor_game' => nil, 'bracket_type' => nil }
+                             'round' => nil, 'winner_game' => nil, 'bracket_type' => nil }
                          ], 'pairings_reported' => 1
                        }
                      ]
@@ -155,7 +155,7 @@ RSpec.describe RoundsController do
                                'ui_metadata' => { 'row_highlighted' => false },
                                'score_label' => ' - ', 'two_for_one' => false,
                                'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil,
-                               'round' => nil, 'successor_game' => nil, 'bracket_type' => nil },
+                               'round' => nil, 'winner_game' => nil, 'bracket_type' => nil },
                              { 'intentional_draw' => false,
                                'player1' => player_with_no_ids('Alice (she/her)'),
                                'player2' => bye_player,
@@ -163,7 +163,7 @@ RSpec.describe RoundsController do
                                'ui_metadata' => { 'row_highlighted' => false },
                                'score_label' => '6 - 0', 'two_for_one' => false,
                                'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil,
-                               'round' => nil, 'successor_game' => nil, 'bracket_type' => nil }
+                               'round' => nil, 'winner_game' => nil, 'bracket_type' => nil }
                            ], 'pairings_reported' => 1
                          }
                        ]
@@ -180,14 +180,14 @@ RSpec.describe RoundsController do
                                'ui_metadata' => { 'row_highlighted' => false },
                                'score_label' => ' - ', 'two_for_one' => false,
                                'table_label' => 'Game 1', 'table_number' => 1, 'self_report' => nil,
-                               'round' => 1, 'successor_game' => 2, 'bracket_type' => 'upper' }
+                               'round' => 1, 'winner_game' => 2, 'bracket_type' => 'upper' }
                            ],
                            'pairings_reported' => 0
                          },
                          {
                            'number' => 2,
                            'pairings' => [
-                             { 'table_number' => 2, 'round' => 2, 'successor_game' => nil,
+                             { 'table_number' => 2, 'round' => 2, 'winner_game' => nil,
                                'bracket_type' => 'upper' }
                            ]
                          }
@@ -227,7 +227,7 @@ RSpec.describe RoundsController do
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => '3 - 0 (C)', 'two_for_one' => false,
                              'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil,
-                             'round' => nil, 'successor_game' => nil, 'bracket_type' => nil },
+                             'round' => nil, 'winner_game' => nil, 'bracket_type' => nil },
                            { 'intentional_draw' => false,
                              'player1' => player_with_no_ids('Alice (she/her)'),
                              'player2' => bye_player,
@@ -235,7 +235,7 @@ RSpec.describe RoundsController do
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => '6 - 0', 'two_for_one' => false,
                              'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil,
-                             'round' => nil, 'successor_game' => nil, 'bracket_type' => nil }
+                             'round' => nil, 'winner_game' => nil, 'bracket_type' => nil }
                          ], 'pairings_reported' => 2
                        }
                      ]
@@ -275,7 +275,7 @@ RSpec.describe RoundsController do
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => '0 - 3 (R)', 'two_for_one' => false,
                              'table_label' => 'Table 1', 'table_number' => 1, 'self_report' => nil,
-                             'round' => nil, 'successor_game' => nil, 'bracket_type' => nil },
+                             'round' => nil, 'winner_game' => nil, 'bracket_type' => nil },
                            { 'intentional_draw' => false,
                              'player1' => player_with_no_ids('Alice (she/her)'),
                              'player2' => bye_player,
@@ -283,7 +283,7 @@ RSpec.describe RoundsController do
                              'ui_metadata' => { 'row_highlighted' => false },
                              'score_label' => '6 - 0', 'two_for_one' => false,
                              'table_label' => 'Table 2', 'table_number' => 2, 'self_report' => nil,
-                             'round' => nil, 'successor_game' => nil, 'bracket_type' => nil }
+                             'round' => nil, 'winner_game' => nil, 'bracket_type' => nil }
                          ], 'pairings_reported' => 2
                        }
                      ]


### PR DESCRIPTION
These changes move the bracket info out of the standard pairings endpoint and into a new endpoint (/tournaments/:id/rounds/brackets) that returns the necessary player and bracket data to construct the elimination bracket(s) on the Bracket tab.

This is dependent upon PR #613.