### PR TITLE
Restrict cuts on pairings

### DIFF
--- a/app/frontend/pairings/Rounds.svelte
+++ b/app/frontend/pairings/Rounds.svelte
@@ -348,7 +348,7 @@
     </div>
 
     <!-- Elimination stage controls -->
-    {#if ctx.showOrganizerView && data.stages.length > 0 && !data.stages[data.stages.length - 1].is_elimination}
+    {#if ctx.showOrganizerView && data.stages.length > 0 && data.stages[data.stages.length - 1].rounds.length > 1 && !data.stages[data.stages.length - 1].is_elimination}
       <h4>Cut to...</h4>
       <table>
         <tbody>

--- a/app/frontend/pairings/Rounds.svelte
+++ b/app/frontend/pairings/Rounds.svelte
@@ -348,7 +348,7 @@
     </div>
 
     <!-- Elimination stage controls -->
-    {#if ctx.showOrganizerView && data.stages.length > 0 && data.stages[data.stages.length - 1].rounds.length > 1 && !data.stages[data.stages.length - 1].is_elimination}
+    {#if ctx.showOrganizerView && data.stages.length > 0 && !data.stages[data.stages.length - 1].is_elimination && data.stages[data.stages.length - 1].rounds.some((r) => r.completed)}
       <h4>Cut to...</h4>
       <table>
         <tbody>

--- a/app/frontend/tests/Rounds.svelte-test.ts
+++ b/app/frontend/tests/Rounds.svelte-test.ts
@@ -69,6 +69,11 @@ describe("Rounds", () => {
         render(Rounds, { tournamentId: 1 });
       });
 
+      it("has no cut links when no rounds have been completed", () => {
+        expect(screen.queryByText(/add swiss stage/i)).not.toBeNull();
+        expect(screen.queryByText(/cut to\.\.\./i)).toBeNull();
+      });
+
       it("creates a new swiss stage", async () => {
         expect(screen.queryByText(/^swiss$/i)).toBeNull();
 
@@ -214,6 +219,11 @@ describe("Rounds", () => {
     describe("with no completed rounds", () => {
       beforeEach(() => {
         render(Rounds, { tournamentId: 1 });
+      });
+
+      it("has no cut links when no rounds have been completed", () => {
+        expect(screen.queryByText(/^swiss$/i)).not.toBeNull();
+        expect(screen.queryByText(/cut to\.\.\./i)).toBeNull();
       });
 
       describe("complete round", () => {
@@ -540,7 +550,7 @@ describe("Rounds", () => {
         expect(screen.queryByText(/round 2/i)).not.toBeNull();
       });
 
-      it("creates a single elim cut stage", async () => {
+      it("shows cut buttons and allows creating single elim stage", async () => {
         expect(screen.queryByText(/^single elim$/i)).toBeNull();
 
         vi.spyOn(MockPairingsData, "stages", "get").mockReturnValue([
@@ -558,7 +568,7 @@ describe("Rounds", () => {
         expect(screen.queryByText(/^single elim$/i)).not.toBeNull();
       });
 
-      it("creates a double elim cut stage", async () => {
+      it("shows cut buttons and allows creating double elim stage", async () => {
         expect(screen.queryByText(/^double elim$/i)).toBeNull();
 
         vi.spyOn(MockPairingsData, "stages", "get").mockReturnValue([
@@ -597,6 +607,7 @@ describe("Rounds", () => {
         expect(screen.queryByText(/unlock all players/i)).toBeNull();
         expect(screen.queryByText(/lock all players/i)).toBeNull();
         expect(screen.queryByText(/pair new round!/i)).toBeNull();
+        expect(screen.queryByText(/cut to\.\.\./i)).toBeNull();
       });
 
       it("the TO stage controls", () => {

--- a/app/views/rounds/index.html.slim
+++ b/app/views/rounds/index.html.slim
@@ -68,47 +68,46 @@
 
     = render @stages
 
-  - if policy(@tournament).update?
-      - if @tournament.stages.empty? 
-        hr
-        h4 Cut to...
-        table
-          tbody
-            tr
-              td Single Elimination
-              td
-                => link_to cut_tournament_path(@tournament, number: 2, elimination_type: 'single'), method: :post, class: 'btn btn-success', id: 'single_elim_top_2' do
-                  => fa_icon 'scissors'
-                  | Top 2
-              td
-                => link_to cut_tournament_path(@tournament, number: 3, elimination_type: 'single'), method: :post, class: 'btn btn-success', id: 'single_elim_top_3' do
-                  => fa_icon 'scissors'
-                  | Top 3
-              td
-                => link_to cut_tournament_path(@tournament, number: 4, elimination_type: 'single'), method: :post, class: 'btn btn-success', id: 'single_elim_top_4' do
-                  => fa_icon 'scissors'
-                  | Top 4
-              td
-                => link_to cut_tournament_path(@tournament, number: 8, elimination_type: 'single'), method: :post, class: 'btn btn-success', id: 'single_elim_top_8' do
-                  => fa_icon 'scissors'
-                  | Top 8
-              td
-                => link_to cut_tournament_path(@tournament, number: 16, elimination_type: 'single'), method: :post, class: 'btn btn-success', id: 'single_elim_top_16' do
-                  => fa_icon 'scissors'
-                  | Top 16
-            tr
-              td Double Elimination
-              td
-              td
-              td
-                => link_to cut_tournament_path(@tournament, number: 4, elimination_type: 'double'), method: :post, class: 'btn btn-success', id: 'double_elim_top_4' do
-                  => fa_icon 'scissors'
-                  | Top 4
-              td
-                => link_to cut_tournament_path(@tournament, number: 8, elimination_type: 'double'), method: :post, class: 'btn btn-success', id: 'double_elim_top_8' do
-                  => fa_icon 'scissors'
-                  | Top 8
-              td
-                => link_to cut_tournament_path(@tournament, number: 16, elimination_type: 'double'), method: :post, class: 'btn btn-success', id: 'double_elim_top_16' do
-                  => fa_icon 'scissors'
-                  | Top 16
+    - if policy(@tournament).update?
+      - if !@stages.last.elimination? && !@stages.last.rounds.where(completed: true).empty?
+          h4 Cut to...
+          table
+            tbody
+              tr
+                td Single Elimination
+                td
+                  => link_to cut_tournament_path(@tournament, number: 2, elimination_type: 'single'), method: :post, class: 'btn btn-success', id: 'single_elim_top_2' do
+                    => fa_icon 'scissors'
+                    | Top 2
+                td
+                  => link_to cut_tournament_path(@tournament, number: 3, elimination_type: 'single'), method: :post, class: 'btn btn-success', id: 'single_elim_top_3' do
+                    => fa_icon 'scissors'
+                    | Top 3
+                td
+                  => link_to cut_tournament_path(@tournament, number: 4, elimination_type: 'single'), method: :post, class: 'btn btn-success', id: 'single_elim_top_4' do
+                    => fa_icon 'scissors'
+                    | Top 4
+                td
+                  => link_to cut_tournament_path(@tournament, number: 8, elimination_type: 'single'), method: :post, class: 'btn btn-success', id: 'single_elim_top_8' do
+                    => fa_icon 'scissors'
+                    | Top 8
+                td
+                  => link_to cut_tournament_path(@tournament, number: 16, elimination_type: 'single'), method: :post, class: 'btn btn-success', id: 'single_elim_top_16' do
+                    => fa_icon 'scissors'
+                    | Top 16
+              tr
+                td Double Elimination
+                td
+                td
+                td
+                  => link_to cut_tournament_path(@tournament, number: 4, elimination_type: 'double'), method: :post, class: 'btn btn-success', id: 'double_elim_top_4' do
+                    => fa_icon 'scissors'
+                    | Top 4
+                td
+                  => link_to cut_tournament_path(@tournament, number: 8, elimination_type: 'double'), method: :post, class: 'btn btn-success', id: 'double_elim_top_8' do
+                    => fa_icon 'scissors'
+                    | Top 8
+                td
+                  => link_to cut_tournament_path(@tournament, number: 16, elimination_type: 'double'), method: :post, class: 'btn btn-success', id: 'double_elim_top_16' do
+                    => fa_icon 'scissors'
+                    | Top 16

--- a/app/views/rounds/index.html.slim
+++ b/app/views/rounds/index.html.slim
@@ -68,46 +68,47 @@
 
     = render @stages
 
-    - if policy(@tournament).update?
-        - unless @stages.last.elimination?
-          h4 Cut to...
-          table
-            tbody
-              tr
-                td Single Elimination
-                td
-                  => link_to cut_tournament_path(@tournament, number: 2, elimination_type: 'single'), method: :post, class: 'btn btn-success', id: 'single_elim_top_2' do
-                    => fa_icon 'scissors'
-                    | Top 2
-                td
-                  => link_to cut_tournament_path(@tournament, number: 3, elimination_type: 'single'), method: :post, class: 'btn btn-success', id: 'single_elim_top_3' do
-                    => fa_icon 'scissors'
-                    | Top 3
-                td
-                  => link_to cut_tournament_path(@tournament, number: 4, elimination_type: 'single'), method: :post, class: 'btn btn-success', id: 'single_elim_top_4' do
-                    => fa_icon 'scissors'
-                    | Top 4
-                td
-                  => link_to cut_tournament_path(@tournament, number: 8, elimination_type: 'single'), method: :post, class: 'btn btn-success', id: 'single_elim_top_8' do
-                    => fa_icon 'scissors'
-                    | Top 8
-                td
-                  => link_to cut_tournament_path(@tournament, number: 16, elimination_type: 'single'), method: :post, class: 'btn btn-success', id: 'single_elim_top_16' do
-                    => fa_icon 'scissors'
-                    | Top 16
-              tr
-                td Double Elimination
-                td
-                td
-                td
-                  => link_to cut_tournament_path(@tournament, number: 4, elimination_type: 'double'), method: :post, class: 'btn btn-success', id: 'double_elim_top_4' do
-                    => fa_icon 'scissors'
-                    | Top 4
-                td
-                  => link_to cut_tournament_path(@tournament, number: 8, elimination_type: 'double'), method: :post, class: 'btn btn-success', id: 'double_elim_top_8' do
-                    => fa_icon 'scissors'
-                    | Top 8
-                td
-                  => link_to cut_tournament_path(@tournament, number: 16, elimination_type: 'double'), method: :post, class: 'btn btn-success', id: 'double_elim_top_16' do
-                    => fa_icon 'scissors'
-                    | Top 16
+  - if policy(@tournament).update?
+      - if @tournament.stages.empty? 
+        hr
+        h4 Cut to...
+        table
+          tbody
+            tr
+              td Single Elimination
+              td
+                => link_to cut_tournament_path(@tournament, number: 2, elimination_type: 'single'), method: :post, class: 'btn btn-success', id: 'single_elim_top_2' do
+                  => fa_icon 'scissors'
+                  | Top 2
+              td
+                => link_to cut_tournament_path(@tournament, number: 3, elimination_type: 'single'), method: :post, class: 'btn btn-success', id: 'single_elim_top_3' do
+                  => fa_icon 'scissors'
+                  | Top 3
+              td
+                => link_to cut_tournament_path(@tournament, number: 4, elimination_type: 'single'), method: :post, class: 'btn btn-success', id: 'single_elim_top_4' do
+                  => fa_icon 'scissors'
+                  | Top 4
+              td
+                => link_to cut_tournament_path(@tournament, number: 8, elimination_type: 'single'), method: :post, class: 'btn btn-success', id: 'single_elim_top_8' do
+                  => fa_icon 'scissors'
+                  | Top 8
+              td
+                => link_to cut_tournament_path(@tournament, number: 16, elimination_type: 'single'), method: :post, class: 'btn btn-success', id: 'single_elim_top_16' do
+                  => fa_icon 'scissors'
+                  | Top 16
+            tr
+              td Double Elimination
+              td
+              td
+              td
+                => link_to cut_tournament_path(@tournament, number: 4, elimination_type: 'double'), method: :post, class: 'btn btn-success', id: 'double_elim_top_4' do
+                  => fa_icon 'scissors'
+                  | Top 4
+              td
+                => link_to cut_tournament_path(@tournament, number: 8, elimination_type: 'double'), method: :post, class: 'btn btn-success', id: 'double_elim_top_8' do
+                  => fa_icon 'scissors'
+                  | Top 8
+              td
+                => link_to cut_tournament_path(@tournament, number: 16, elimination_type: 'double'), method: :post, class: 'btn btn-success', id: 'double_elim_top_16' do
+                  => fa_icon 'scissors'
+                  | Top 16

--- a/spec/feature/tournaments/cut_tournament_spec.rb
+++ b/spec/feature/tournaments/cut_tournament_spec.rb
@@ -34,12 +34,37 @@ RSpec.describe 'cutting tournament', type: :feature do
       end
     end
 
-    context 'on rounds page' do
+    context 'on pairings page with no completed rounds' do
       before do
         visit tournament_rounds_path(tournament)
       end
 
-      it 'creates double elim stage' do
+      it 'has no cut links when no rounds have been completed' do
+        expect(page).to have_text('Swiss') # Shows a default stage.
+        expect(page).to have_no_text('Cut to Top')
+      end
+    end
+
+    context 'on pairings page with no stages' do
+      before do
+        tournament.stages.destroy_all
+        visit tournament_rounds_path(tournament)
+      end
+
+      it 'has no cut links when no rounds have been completed' do
+        expect(page).to have_text('Add Swiss stage')
+        expect(page).to have_no_text('Cut to Top')
+      end
+    end
+
+    context 'on pairings page with a completed swiss round' do
+      before do
+        create(:round, stage: tournament.stages.first, completed: true)
+
+        visit tournament_rounds_path(tournament)
+      end
+
+      it 'shows cut buttons and allows creating double elim stage' do
         expect(tournament.stages.size).to eq(1)
 
         find("a[id='double_elim_top_8']").click
@@ -48,7 +73,7 @@ RSpec.describe 'cutting tournament', type: :feature do
         expect(tournament.stages.last.format).to eq('double_elim')
       end
 
-      it 'creates single elim stage' do
+      it 'shows cut buttons and allows creating single elim stage' do
         expect(tournament.stages.size).to eq(1)
 
         find("a[id='single_elim_top_4']").click


### PR DESCRIPTION
This updates when the cut buttons show up on the pairings page for TOs.

Tournament w/swiss stage & no rounds: no cut buttons
<img width="1057" height="500" alt="classic-no-pairings-swiss" src="https://github.com/user-attachments/assets/10a4e2a8-25e0-493a-9b47-62f2c57c043a" />

Tournament w/swiss stage and pairings, but no completed rounds: no cut buttons
<img width="1062" height="576" alt="classic-no-completed-swiss-round" src="https://github.com/user-attachments/assets/404fe05e-bb01-4547-b6e7-a2d48ba03963" />



Tournament w/swiss stage & completed round: cut buttons
<img width="1090" height="671" alt="classic-completed-swiss-round" src="https://github.com/user-attachments/assets/03e8dfe1-aece-4ccc-b8a2-f83188f9be74" />


Tournament w/no stages: no cut buttons, only "Add Swiss stage"
<img width="1056" height="254" alt="Screenshot 2026-09-04 at 1 36 20 AM" src="https://github.com/user-attachments/assets/824bf8cf-3dcf-40c4-a1ca-1b656d00f143" />