### PR TITLE
Fix nil reference when no rounds exist

### DIFF
--- a/app/controllers/beta/tournaments_controller.rb
+++ b/app/controllers/beta/tournaments_controller.rb
@@ -205,7 +205,7 @@ module Beta
         running: current_round&.timer&.running?,
         paused: current_round&.timer&.paused?,
         started: current_round&.timer&.started?,
-        state: current_round.timer&.state
+        state: current_round&.timer&.state
       }
     end
 


### PR DESCRIPTION
found this while working on the svelte conversion.