### PR TITLE
Adding missing tournament data

### DIFF
--- a/app/controllers/beta/tournaments_controller.rb
+++ b/app/controllers/beta/tournaments_controller.rb
@@ -19,7 +19,7 @@ module Beta
       respond_to do |format|
         format.html
         format.json do
-          render json: { tournament: @tournament, csrf_token: form_authenticity_token }
+          render json: { tournament: helpers.tournament_json(@tournament), csrf_token: form_authenticity_token }
         end
       end
     end

--- a/app/helpers/tournament_helper.rb
+++ b/app/helpers/tournament_helper.rb
@@ -43,6 +43,8 @@ module TournamentHelper # rubocop:disable Style/Documentation
       format_id: tournament.format_id,
       deckbuilding_restriction_id: tournament.deckbuilding_restriction_id,
       card_set_id: tournament.card_set_id,
+      active_player_count: tournament.players.active.count,
+      dropped_player_count: tournament.players.dropped.count,
       created_at: tournament.created_at,
       updated_at: tournament.updated_at
     }

--- a/spec/requests/rounds_controller_spec.rb
+++ b/spec/requests/rounds_controller_spec.rb
@@ -444,6 +444,7 @@ RSpec.describe RoundsController do
   def default_tournament
     {
       'abr_code' => nil,
+      'active_player_count' => 3,
       'additional_prizes_description' => nil,
       'all_players_unlocked' => true,
       'allow_self_reporting' => false,
@@ -454,6 +455,7 @@ RSpec.describe RoundsController do
       'deckbuilding_restriction_id' => nil,
       'decklist_required' => false,
       'description' => nil,
+      'dropped_player_count' => 0,
       'event_link' => nil,
       'format_id' => nil,
       'id' => tournament.id,

--- a/spec/requests/tournaments_controller_edit_form_spec.rb
+++ b/spec/requests/tournaments_controller_edit_form_spec.rb
@@ -42,12 +42,14 @@ RSpec.describe TournamentsController do
         data['tournament']&.delete 'updated_at'
         expect(data['tournament']).to eq(
           {
+            'active_player_count' => 0,
             'all_players_unlocked' => true,
             'allow_self_reporting' => false,
             'any_player_unlocked' => true,
             'cut_deck_visibility' => 'cut_decks_private',
             'date' => '2023-05-15',
             'decklist_required' => false,
+            'dropped_player_count' => 0,
             'id' => tournament.id,
             'manual_seed' => true,
             'name' => 'Test Tournament',

--- a/spec/requests/tournaments_controller_new_form_spec.rb
+++ b/spec/requests/tournaments_controller_new_form_spec.rb
@@ -25,7 +25,9 @@ RSpec.describe TournamentsController do
         data = response.parsed_body
         expect(data['tournament']).to eq(
           {
+            'active_player_count' => 0,
             'date' => '2023-05-15',
+            'dropped_player_count' => 0,
             'private' => false,
             'swiss_format' => 'double_sided',
             'allow_self_reporting' => false,


### PR DESCRIPTION
This is a quick solution that adds some tournament data that got missed when the page was initially copied over (the SSR page previously had access to data that needed to be added to the JSON returned to the SPA).

The necessary data is returned by the API so I spent some time trying to call the API method from this non-tournament controller. I was able to do it, but there are some formatting issues that ended up being way messier to resolve than this (also I'm not sure what the best practice for doing something like this is). I'm calling the non-API endpoint for this data in the first place because I also need a CSRF token to make subsequent calls from this page work. Some questions (possibly for future work if this current solution is acceptable):
- How should CSRF tokens be handled as we move more calls to the API?
- Should non-API controllers retrieve data from the API endpoints? The client could get the tournament data from the API as normal, but then what does it do for a CSRF token - make a separate call just for that?