### PR TITLE
frontend tournament 'Me' tab migration

### DIFF
--- a/frontend/src/lib/utils/transformations.test.ts
+++ b/frontend/src/lib/utils/transformations.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { CreateMyTournamentSummary } from "./transformations";
+import type { PairingsData } from "../../routes/tournaments/[tournamentId]/api_helper";
+import type { Player } from "$lib/model/Player";
+import type { Round } from "$lib/model/Round";
+
+const createPlayer = (overrides: Partial<Player>): Player => ({
+  side: null,
+  corp_id: {} as never,
+  runner_id: {} as never,
+  pronouns: "",
+  side_label: null,
+  registration_locked: false,
+  include_in_stream: false,
+  active: true,
+  first_round_bye: false,
+  manual_seed: null,
+  fixed_table_number: null,
+  ...overrides
+} as Player);
+
+const createRound = (overrides: Partial<Round>): Round => ({
+  id: 1,
+  number: 1,
+  completed: true,
+  pairings: [],
+  pairings_reported: 1,
+  length_minutes: 0,
+  timer: {} as never,
+  unpaired_players: [],
+  ...overrides
+});
+
+const alice = createPlayer({
+  id: 1,
+  user_id: 1,
+  name: "Alice",
+  name_with_pronouns: "Alice",
+  corp_id: { name: "Corp" } as never,
+  runner_id: { name: "Runner" } as never
+});
+
+const bob = createPlayer({
+  id: 2,
+  user_id: 2,
+  name: "Bob",
+  name_with_pronouns: "Bob"
+});
+
+const bye = createPlayer({
+  id: 0,
+  user_id: 0,
+  name: "Bye",
+  name_with_pronouns: "Bye"
+});
+
+describe("transformations", () => {
+  describe("CreateMyTournamentSummary", () => {
+    it("handles undefined data", () => {
+      const summary = CreateMyTournamentSummary(undefined, 1);
+      expect(summary.total.wins).toBe(0);
+      expect(summary.pairings.length).toBe(0);
+    });
+
+    it("handles null data", () => {
+      const summary = CreateMyTournamentSummary(null, 1);
+      expect(summary.total.wins).toBe(0);
+      expect(summary.pairings.length).toBe(0);
+    });
+
+    it("handles missing userId", () => {
+      const summary = CreateMyTournamentSummary(null, undefined);
+      expect(summary.total.wins).toBe(0);
+      expect(summary.pairings.length).toBe(0);
+    });
+
+    it("processes a bye correctly", () => {
+      const data: PairingsData = {
+        // tournament: {} as never,
+        policy: { update: false, custom_table_numbering: false },
+        stages: [{
+          id: 1, name: "Swiss", format: "swiss", is_single_sided: true, is_elimination: false, view_decks: false,
+          rounds: [
+            createRound({
+              pairings: [{
+                id: 10, table_number: 1, table_label: "1", policy: { self_report: false },
+                reported: true, intentional_draw: false, two_for_one: false, self_reports: null, winner_game: null, loser_game: null, bracket_type: null, ui_metadata: { row_highlighted: false },
+                score1: 3, score2: 0, score1_corp: 0, score1_runner: 0, score2_corp: 0, score2_runner: 0, score_label: "Bye",
+                player1: alice,
+                player2: bye
+              }]
+            })
+          ]
+        }]
+      };
+
+      const summary = CreateMyTournamentSummary(data, 1);
+      expect(summary.total.wins).toBe(1);
+      expect(summary.total.points).toBe(3);
+      expect(summary.pairings[0].cumulativePoints).toBe(3);
+    });
+
+    it("processes a normal round win, loss, and tie, checking cumulative points", () => {
+      const createPairing = (id: number, score1: number, score2: number, corp1: number, run1: number, reported = true) => ({
+        id, table_number: 1, table_label: "1", policy: { self_report: false },
+        reported, intentional_draw: false, two_for_one: false, self_reports: null, winner_game: null, loser_game: null, bracket_type: null, ui_metadata: { row_highlighted: false },
+        score1, score2, score1_corp: corp1, score1_runner: run1, score2_corp: 0, score2_runner: 0, score_label: "Done",
+        player1: alice,
+        player2: bob
+      });
+
+      const data: PairingsData = {
+        // tournament: {} as never,
+        policy: { update: false, custom_table_numbering: false },
+        stages: [{
+          id: 1, name: "Swiss", format: "swiss", is_single_sided: true, is_elimination: false, view_decks: false,
+          rounds: [
+            createRound({ id: 1, number: 1, pairings: [createPairing(101, 3, 0, 3, 0)] }),
+            createRound({ id: 2, number: 2, pairings: [createPairing(102, 0, 3, 0, 0)] }),
+            createRound({ id: 3, number: 3, pairings: [createPairing(103, 1, 1, 0, 0)] })
+          ]
+        }]
+      };
+
+      const summary = CreateMyTournamentSummary(data, 1);
+
+      expect(summary.total.wins).toBe(1);
+      expect(summary.total.losses).toBe(1);
+      expect(summary.total.ties).toBe(1);
+      expect(summary.total.points).toBe(4); // 3 + 0 + 1
+
+      expect(summary.corpIdentity?.name).toBe("Corp");
+      expect(summary.runnerIdentity?.name).toBe("Runner");
+
+      // Cumulative points check
+      expect(summary.pairings[0].cumulativePoints).toBe(3);
+      expect(summary.pairings[1].cumulativePoints).toBe(3); // 3 + 0
+      expect(summary.pairings[2].cumulativePoints).toBe(4); // 3 + 0 + 1
+    });
+  });
+});

--- a/frontend/src/lib/utils/transformations.test.ts
+++ b/frontend/src/lib/utils/transformations.test.ts
@@ -31,20 +31,20 @@ const createRound = (overrides: Partial<Round>): Round => ({
   ...overrides
 });
 
-const alice = createPlayer({
+const evie = createPlayer({
   id: 1,
   user_id: 1,
-  name: "Alice",
-  name_with_pronouns: "Alice",
+  name: "evie",
+  name_with_pronouns: "evie (she/her)",
   corp_id: { name: "Corp" } as never,
   runner_id: { name: "Runner" } as never
 });
 
-const bob = createPlayer({
+const locks = createPlayer({
   id: 2,
   user_id: 2,
-  name: "Bob",
-  name_with_pronouns: "Bob"
+  name: "locks",
+  name_with_pronouns: "locks (he/him)"
 });
 
 const bye = createPlayer({
@@ -86,7 +86,7 @@ describe("transformations", () => {
                 id: 10, table_number: 1, table_label: "1", policy: { self_report: false },
                 reported: true, intentional_draw: false, two_for_one: false, self_reports: null, winner_game: null, loser_game: null, bracket_type: null, ui_metadata: { row_highlighted: false },
                 score1: 3, score2: 0, score1_corp: 0, score1_runner: 0, score2_corp: 0, score2_runner: 0, score_label: "Bye",
-                player1: alice,
+                player1: evie,
                 player2: bye
               }]
             })
@@ -105,8 +105,8 @@ describe("transformations", () => {
         id, table_number: 1, table_label: "1", policy: { self_report: false },
         reported, intentional_draw: false, two_for_one: false, self_reports: null, winner_game: null, loser_game: null, bracket_type: null, ui_metadata: { row_highlighted: false },
         score1, score2, score1_corp: corp1, score1_runner: run1, score2_corp: 0, score2_runner: 0, score_label: "Done",
-        player1: alice,
-        player2: bob
+        player1: evie,
+        player2: locks
       });
 
       const data: PairingsData = {

--- a/frontend/src/lib/utils/transformations.ts
+++ b/frontend/src/lib/utils/transformations.ts
@@ -1,0 +1,123 @@
+// Types and transformation code to transform data between the implicit API and data structures needed by varioius pages.
+
+import type { Identity as IdentityType } from "$lib/model/Identity";
+import type { PairingsData } from "../../routes/tournaments/[tournamentId]/api_helper";
+import type { Pairing } from "$lib/model/Pairing";
+import type { Round } from "$lib/model/Round";
+import type { Stage } from "$lib/model/Stage";
+
+export interface ScoreSummary {
+  wins: number;
+  losses: number;
+  ties: number;
+}
+
+export type MyTournamentPairing = Pairing & {
+  stage: Stage;
+  round: Round;
+  cumulativePoints: number | null;
+};
+
+export interface MyTournamentSummary {
+  total: ScoreSummary & { points: number };
+  corp: ScoreSummary;
+  runner: ScoreSummary;
+  corpIdentity: IdentityType | undefined;
+  runnerIdentity: IdentityType | undefined;
+  pairings: MyTournamentPairing[];
+}
+
+// Transform pairings data into a data structure to power the "Me" page for a tournament
+export function CreateMyTournamentSummary(
+  data: PairingsData | null | undefined,
+  userId?: number | null,
+): MyTournamentSummary {
+  const result: MyTournamentSummary = {
+    total: { wins: 0, losses: 0, ties: 0, points: 0 },
+    corp: { wins: 0, losses: 0, ties: 0 },
+    runner: { wins: 0, losses: 0, ties: 0 },
+    corpIdentity: undefined,
+    runnerIdentity: undefined,
+    // pairings are sorted by stage # and round # and will indicate if they are elimination or swiss rounds.
+    pairings: [],
+  };
+  if (!data || !userId) return result;
+
+  let pts = 0;
+
+  for (const stage of data.stages) {
+    for (const round of stage.rounds) {
+      for (const pairing of round.pairings) {
+        const isMe1 = pairing.player1.user_id === userId;
+        const isMe2 = pairing.player2.user_id === userId;
+
+        if (!isMe1 && !isMe2) continue;
+
+        if (!result.corpIdentity || !result.runnerIdentity) {
+          const myPlayer = isMe1 ? pairing.player1 : pairing.player2;
+          if (myPlayer.corp_id.name) result.corpIdentity = myPlayer.corp_id;
+          if (myPlayer.runner_id.name) result.runnerIdentity = myPlayer.runner_id;
+        }
+
+        let cumulativePoints: number | null = null;
+        const isBye = pairing.player1.id === 0 || pairing.player2.id === 0;
+
+        if (!stage.is_elimination) {
+          if (isBye) {
+            pts += isMe1 ? pairing.score1 : pairing.score2;
+            cumulativePoints = pts;
+          } else if (pairing.reported) {
+            pts += isMe1 ? pairing.score1 : pairing.score2;
+            cumulativePoints = pts;
+          }
+        }
+
+        result.pairings.push({
+          ...pairing,
+          stage,
+          round,
+          cumulativePoints
+        });
+
+        if (isBye) {
+          result.total.wins += 1;
+          result.total.points += isMe1 ? pairing.score1 : pairing.score2;
+          continue;
+        }
+
+        if (!pairing.reported) continue;
+
+        const myScore = isMe1 ? pairing.score1 : pairing.score2;
+        const oppScore = isMe1 ? pairing.score2 : pairing.score1;
+
+        result.total.points += myScore;
+
+        if (myScore > oppScore) result.total.wins += 1;
+        else if (myScore < oppScore) result.total.losses += 1;
+        else result.total.ties += 1;
+
+        let mySide = "";
+        if (stage.is_single_sided) {
+          mySide = isMe1 ? (pairing.player1.side ?? "") : (pairing.player2.side ?? "");
+        }
+
+        if (!stage.is_single_sided || mySide === "corp") {
+          const myCorp = stage.is_single_sided ? myScore : (isMe1 ? pairing.score1_corp : pairing.score2_corp);
+          const oppRunner = stage.is_single_sided ? oppScore : (isMe1 ? pairing.score2_runner : pairing.score1_runner);
+          if (myCorp > oppRunner) result.corp.wins += 1;
+          else if (myCorp < oppRunner) result.corp.losses += 1;
+          else result.corp.ties += 1;
+        }
+
+        if (!stage.is_single_sided || mySide === "runner") {
+          const myRunner = stage.is_single_sided ? myScore : (isMe1 ? pairing.score1_runner : pairing.score2_runner);
+          const oppCorp = stage.is_single_sided ? oppScore : (isMe1 ? pairing.score2_corp : pairing.score1_corp);
+          if (myRunner > oppCorp) result.runner.wins += 1;
+          else if (myRunner < oppCorp) result.runner.losses += 1;
+          else result.runner.ties += 1;
+        }
+      }
+    }
+  }
+  return result;
+}

--- a/frontend/src/routes/tournaments/[tournamentId]/+layout.svelte
+++ b/frontend/src/routes/tournaments/[tournamentId]/+layout.svelte
@@ -29,6 +29,12 @@
   }
 </style>
 
+<svelte:head>
+  {#if data.tournamentData?.csrf_token}
+    <meta name="csrf-token" content={data.tournamentData.csrf_token} />
+  {/if}
+</svelte:head>
+
 <!-- Tournament header -->
 <div class="row dontprint">
   <div class="col-md">
@@ -59,14 +65,13 @@
       <FontAwesomeIcon icon="trophy" /> Tournament
     </a>
   </li>
-  
-  <!-- TODO: Remove the 'as string' casts throughout once the route id exists. -->
-  {#if data.player}
+
+  {#if authStore.user}
     <li class="nav-item">
     <a
-      href={resolve(`/tournaments/${tournament.id}/my_tournament`)}
+      href={resolve(`/tournaments/${tournament.id}/me`)}
       class="nav-link"
-      class:active={page.route.id as string === "/tournaments/[tournamentId]/my_tournament"}
+      class:active={page.route.id as string === "/tournaments/[tournamentId]/me"}
     >
         <FontAwesomeIcon icon="user" /> Me
       </a>

--- a/frontend/src/routes/tournaments/[tournamentId]/+layout.svelte
+++ b/frontend/src/routes/tournaments/[tournamentId]/+layout.svelte
@@ -30,7 +30,7 @@
 </style>
 
 <svelte:head>
-  {#if data.tournamentData?.csrf_token}
+  {#if data.tournamentData.csrf_token}
     <meta name="csrf-token" content={data.tournamentData.csrf_token} />
   {/if}
 </svelte:head>

--- a/frontend/src/routes/tournaments/[tournamentId]/api_helper.test.ts
+++ b/frontend/src/routes/tournaments/[tournamentId]/api_helper.test.ts
@@ -7,7 +7,23 @@ import {
 import type { ScoreReport } from "$lib/model/ScoreReport";
 
 describe("tournament api_helper score reporting", () => {
-  const mockFetch = vi.fn();
+  const mockFetch = vi.fn<typeof fetch>();
+
+  function getFetchCall(callIndex = 0) {
+    const [input, init] = mockFetch.mock.calls[callIndex];
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    const body =
+      typeof init?.body === "string"
+        ? (JSON.parse(init.body) as Record<string, unknown>)
+        : {};
+    return { url, init, headers, body };
+  }
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -21,11 +37,11 @@ describe("tournament api_helper score reporting", () => {
 
       expect(result).toBe(true);
       expect(mockFetch).toHaveBeenCalledTimes(1);
-      const [url, options] = mockFetch.mock.calls[0];
+      const { url, init, body } = getFetchCall();
       expect(url).toContain("/beta/tournaments/10/rounds/2/pairings/42/report");
-      expect(options.method).toBe("POST");
-      expect(options.credentials).toBe("include");
-      expect(JSON.parse(options.body)).toEqual({ side: "player1_is_corp" });
+      expect(init?.method).toBe("POST");
+      expect(init?.credentials).toBe("include");
+      expect(body).toEqual({ side: "player1_is_corp" });
     });
 
     it("returns false when response is not ok", async () => {
@@ -57,12 +73,11 @@ describe("tournament api_helper score reporting", () => {
 
       expect(result).toBe(true);
       expect(mockFetch).toHaveBeenCalledTimes(1);
-      const [url, options] = mockFetch.mock.calls[0];
+      const { url, init, body } = getFetchCall();
       expect(url).toContain("/beta/tournaments/10/rounds/2/pairings/42/report");
-      expect(options.method).toBe("POST");
-      const parsedBody = JSON.parse(options.body);
-      expect(parsedBody.self_report).toBe(true);
-      expect(parsedBody.pairing).toEqual({
+      expect(init?.method).toBe("POST");
+      expect(body.self_report).toBe(true);
+      expect(body.pairing).toEqual({
         score1: 3,
         score2: 0,
         score1_corp: 3,
@@ -71,8 +86,9 @@ describe("tournament api_helper score reporting", () => {
         score2_corp: 0,
         intentional_draw: false,
       });
-      expect(parsedBody.pairing.label).toBeUndefined();
-      expect(parsedBody.pairing.extra_self_report_label).toBeUndefined();
+      const pairing = body.pairing as Record<string, unknown>;
+      expect(pairing.label).toBeUndefined();
+      expect(pairing.extra_self_report_label).toBeUndefined();
     });
 
     it("returns false on network error", async () => {
@@ -102,12 +118,12 @@ describe("tournament api_helper score reporting", () => {
 
       expect(result).toBe(true);
       expect(mockFetch).toHaveBeenCalledTimes(1);
-      const [url, options] = mockFetch.mock.calls[0];
+      const { url, init } = getFetchCall();
       expect(url).toContain(
         "/beta/tournaments/10/rounds/2/pairings/42/reset_self_report",
       );
-      expect(options.method).toBe("DELETE");
-      expect(options.credentials).toBe("include");
+      expect(init?.method).toBe("DELETE");
+      expect(init?.credentials).toBe("include");
     });
 
     it("sends explicit csrf token in headers", async () => {
@@ -117,9 +133,9 @@ describe("tournament api_helper score reporting", () => {
 
       expect(result).toBe(true);
       expect(mockFetch).toHaveBeenCalledTimes(1);
-      const [url, options] = mockFetch.mock.calls[0];
+      const { url, headers } = getFetchCall();
       expect(url).not.toContain("//beta");
-      expect(options.headers["X-CSRF-Token"]).toBe("explicit-csrf-token");
+      expect(headers["X-CSRF-Token"]).toBe("explicit-csrf-token");
     });
   });
 
@@ -139,9 +155,9 @@ describe("tournament api_helper score reporting", () => {
 
       await reportScore(10, 2, 42, report, true, "test-csrf-token", mockFetch);
 
-      const [url, options] = mockFetch.mock.calls[0];
+      const { url, headers } = getFetchCall();
       expect(url).not.toContain("//beta");
-      expect(options.headers["X-CSRF-Token"]).toBe("test-csrf-token");
+      expect(headers["X-CSRF-Token"]).toBe("test-csrf-token");
     });
 
     it("uses explicit csrf token when provided to changePlayerSide", async () => {
@@ -149,9 +165,9 @@ describe("tournament api_helper score reporting", () => {
 
       await changePlayerSide(10, 2, 42, "runner", "test-side-token", mockFetch);
 
-      const [url, options] = mockFetch.mock.calls[0];
+      const { url, headers } = getFetchCall();
       expect(url).not.toContain("//beta");
-      expect(options.headers["X-CSRF-Token"]).toBe("test-side-token");
+      expect(headers["X-CSRF-Token"]).toBe("test-side-token");
     });
   });
 });

--- a/frontend/src/routes/tournaments/[tournamentId]/api_helper.test.ts
+++ b/frontend/src/routes/tournaments/[tournamentId]/api_helper.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  changePlayerSide,
+  reportScore,
+  resetReports,
+} from "./api_helper";
+import type { ScoreReport } from "$lib/model/ScoreReport";
+
+describe("tournament api_helper score reporting", () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("changePlayerSide", () => {
+    it("sends POST request with side data", async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+      const result = await changePlayerSide(10, 2, 42, "corp", mockFetch);
+
+      expect(result).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toContain("/beta/tournaments/10/rounds/2/pairings/42/report");
+      expect(options.method).toBe("POST");
+      expect(options.credentials).toBe("include");
+      expect(JSON.parse(options.body)).toEqual({ side: "player1_is_corp" });
+    });
+
+    it("returns false when response is not ok", async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 500 }));
+
+      const result = await changePlayerSide(10, 2, 42, "corp", mockFetch);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("reportScore", () => {
+    it("strips UI labels and sends POST with pairing and self_report", async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+      const report: ScoreReport = {
+        score1: 3,
+        score2: 0,
+        score1_corp: 3,
+        score2_runner: 0,
+        score1_runner: 0,
+        score2_corp: 0,
+        intentional_draw: false,
+        label: "3-0",
+        extra_self_report_label: "Player 1 wins",
+      };
+
+      const result = await reportScore(10, 2, 42, report, true, mockFetch);
+
+      expect(result).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toContain("/beta/tournaments/10/rounds/2/pairings/42/report");
+      expect(options.method).toBe("POST");
+      const parsedBody = JSON.parse(options.body);
+      expect(parsedBody.self_report).toBe(true);
+      expect(parsedBody.pairing).toEqual({
+        score1: 3,
+        score2: 0,
+        score1_corp: 3,
+        score2_runner: 0,
+        score1_runner: 0,
+        score2_corp: 0,
+        intentional_draw: false,
+      });
+      expect(parsedBody.pairing.label).toBeUndefined();
+      expect(parsedBody.pairing.extra_self_report_label).toBeUndefined();
+    });
+
+    it("returns false on network error", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("Network failed"));
+
+      const report: ScoreReport = {
+        score1: 3,
+        score2: 0,
+        score1_corp: 3,
+        score2_runner: 0,
+        score1_runner: 0,
+        score2_corp: 0,
+        intentional_draw: false,
+      };
+
+      const result = await reportScore(10, 2, 42, report, false, mockFetch);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("resetReports", () => {
+    it("sends DELETE request to reset_self_report endpoint", async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+      const result = await resetReports(10, 2, 42, mockFetch);
+
+      expect(result).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toContain(
+        "/beta/tournaments/10/rounds/2/pairings/42/reset_self_report",
+      );
+      expect(options.method).toBe("DELETE");
+      expect(options.credentials).toBe("include");
+    });
+
+    it("sends explicit csrf token in headers", async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+      const result = await resetReports(10, 2, 42, "explicit-csrf-token", mockFetch);
+
+      expect(result).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).not.toContain("//beta");
+      expect(options.headers["X-CSRF-Token"]).toBe("explicit-csrf-token");
+    });
+  });
+
+  describe("csrf token and URL formatting", () => {
+    it("uses explicit csrf token when provided to reportScore", async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+      const report: ScoreReport = {
+        score1: 3,
+        score2: 0,
+        score1_corp: 3,
+        score2_runner: 0,
+        score1_runner: 0,
+        score2_corp: 0,
+        intentional_draw: false,
+      };
+
+      await reportScore(10, 2, 42, report, true, "test-csrf-token", mockFetch);
+
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).not.toContain("//beta");
+      expect(options.headers["X-CSRF-Token"]).toBe("test-csrf-token");
+    });
+
+    it("uses explicit csrf token when provided to changePlayerSide", async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+      await changePlayerSide(10, 2, 42, "runner", "test-side-token", mockFetch);
+
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).not.toContain("//beta");
+      expect(options.headers["X-CSRF-Token"]).toBe("test-side-token");
+    });
+  });
+});

--- a/frontend/src/routes/tournaments/[tournamentId]/api_helper.test.ts
+++ b/frontend/src/routes/tournaments/[tournamentId]/api_helper.test.ts
@@ -10,19 +10,19 @@ describe("tournament api_helper score reporting", () => {
   const mockFetch = vi.fn<typeof fetch>();
 
   function getFetchCall(callIndex = 0) {
-    const [input, init] = mockFetch.mock.calls[callIndex];
+    const [input, requestOptions] = mockFetch.mock.calls[callIndex];
     const url =
       typeof input === "string"
         ? input
         : input instanceof URL
           ? input.href
           : input.url;
-    const headers = (init?.headers ?? {}) as Record<string, string>;
+    const headers = (requestOptions?.headers ?? {}) as Record<string, string>;
     const body =
-      typeof init?.body === "string"
-        ? (JSON.parse(init.body) as Record<string, unknown>)
+      typeof requestOptions?.body === "string"
+        ? (JSON.parse(requestOptions.body) as Record<string, unknown>)
         : {};
-    return { url, init, headers, body };
+    return { url, requestOptions, headers, body };
   }
 
   beforeEach(() => {
@@ -37,10 +37,10 @@ describe("tournament api_helper score reporting", () => {
 
       expect(result).toBe(true);
       expect(mockFetch).toHaveBeenCalledTimes(1);
-      const { url, init, body } = getFetchCall();
+      const { url, requestOptions, body } = getFetchCall();
       expect(url).toContain("/beta/tournaments/10/rounds/2/pairings/42/report");
-      expect(init?.method).toBe("POST");
-      expect(init?.credentials).toBe("include");
+      expect(requestOptions?.method).toBe("POST");
+      expect(requestOptions?.credentials).toBe("include");
       expect(body).toEqual({ side: "player1_is_corp" });
     });
 
@@ -73,9 +73,9 @@ describe("tournament api_helper score reporting", () => {
 
       expect(result).toBe(true);
       expect(mockFetch).toHaveBeenCalledTimes(1);
-      const { url, init, body } = getFetchCall();
+      const { url, requestOptions, body } = getFetchCall();
       expect(url).toContain("/beta/tournaments/10/rounds/2/pairings/42/report");
-      expect(init?.method).toBe("POST");
+      expect(requestOptions?.method).toBe("POST");
       expect(body.self_report).toBe(true);
       expect(body.pairing).toEqual({
         score1: 3,
@@ -118,12 +118,12 @@ describe("tournament api_helper score reporting", () => {
 
       expect(result).toBe(true);
       expect(mockFetch).toHaveBeenCalledTimes(1);
-      const { url, init } = getFetchCall();
+      const { url, requestOptions } = getFetchCall();
       expect(url).toContain(
         "/beta/tournaments/10/rounds/2/pairings/42/reset_self_report",
       );
-      expect(init?.method).toBe("DELETE");
-      expect(init?.credentials).toBe("include");
+      expect(requestOptions?.method).toBe("DELETE");
+      expect(requestOptions?.credentials).toBe("include");
     });
 
     it("sends explicit csrf token in headers", async () => {

--- a/frontend/src/routes/tournaments/[tournamentId]/api_helper.ts
+++ b/frontend/src/routes/tournaments/[tournamentId]/api_helper.ts
@@ -1,10 +1,14 @@
 import { COBRA_API_SERVER } from "$app/env/public";
+import type { ScoreReport } from "$lib/model/ScoreReport";
 import type { Stage } from "$lib/model/Stage";
 import type { Stats, CutStats } from "$lib/model/Stats";
 import { TournamentPolicies } from "$lib/model/Tournament";
 import { globalMessages } from "$lib/utils/GlobalMessageState.svelte";
+import { csrfToken } from "../api_helper";
 
-class PairingsData {
+const apiServer = (COBRA_API_SERVER || "").replace(/\/$/, "");
+
+export class PairingsData {
   policy = new TournamentPolicies();
   stages: Stage[] = [];
   warnings?: string[] = [];
@@ -16,8 +20,8 @@ export async function loadPairings(
   altFetch = fetch,
 ) {
   const url = userId
-    ? `${COBRA_API_SERVER}/tournaments/${tournamentId}/rounds/pairings_data/${userId}`
-    : `${COBRA_API_SERVER}/beta/tournaments/${tournamentId}/rounds/pairings_data`;
+    ? `${apiServer}/tournaments/${tournamentId}/rounds/pairings_data/${userId}`
+    : `${apiServer}/beta/tournaments/${tournamentId}/rounds/pairings_data`;
 
   const response = await altFetch(url, {
     method: "GET",
@@ -33,7 +37,7 @@ export async function loadPairings(
 
 export async function loadStats(tournamentId: number, altFetch = fetch): Promise<Stats> {
   const response = await altFetch(
-    `${COBRA_API_SERVER}/beta/tournaments/${tournamentId}/id_and_faction_data`,
+    `${apiServer}/beta/tournaments/${tournamentId}/id_and_faction_data`,
     {
       method: "GET",
     },
@@ -44,11 +48,152 @@ export async function loadStats(tournamentId: number, altFetch = fetch): Promise
 
 export async function loadCutStats(tournamentId: number, altFetch = fetch): Promise<CutStats> {
   const response = await altFetch(
-    `${COBRA_API_SERVER}/beta/tournaments/${tournamentId}/cut_conversion_rates`,
+    `${apiServer}/beta/tournaments/${tournamentId}/cut_conversion_rates`,
     {
       method: "GET",
     },
   );
 
   return (await response.json()) as CutStats;
+}
+
+function resolveCsrfAndFetch(
+  csrfOrFetch?: string | typeof fetch,
+  altFetch: typeof fetch = fetch,
+): { token: string; customFetch: typeof fetch } {
+  let token = "";
+  let customFetch = altFetch;
+
+  if (typeof csrfOrFetch === "function") {
+    customFetch = csrfOrFetch;
+  } else if (typeof csrfOrFetch === "string") {
+    token = csrfOrFetch;
+  }
+
+  if (!token) {
+    token = csrfToken();
+  }
+
+  return { token, customFetch };
+}
+
+export async function changePlayerSide(
+  tournamentId: number,
+  roundId: number,
+  pairingId: number,
+  side: string,
+  csrfOrFetch?: string | typeof fetch,
+  altFetch = fetch,
+): Promise<boolean> {
+  const { token, customFetch } = resolveCsrfAndFetch(csrfOrFetch, altFetch);
+
+  try {
+    const response = await customFetch(
+      `${apiServer}/beta/tournaments/${tournamentId}/rounds/${roundId}/pairings/${pairingId}/report`,
+      {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+          "X-CSRF-Token": token,
+        },
+        body: JSON.stringify({ side: `player1_is_${side}` }),
+      },
+    );
+
+    if (!response.ok) {
+      globalMessages.errors.push("Failed to change player side.");
+      return false;
+    }
+
+    return true;
+  } catch (e) {
+    const err = e as Error;
+    globalMessages.errors.push(`Failed to change player side: ${err.message}`);
+    return false;
+  }
+}
+
+export async function reportScore(
+  tournamentId: number,
+  roundId: number,
+  pairingId: number,
+  data: ScoreReport,
+  selfReport: boolean,
+  csrfOrFetch?: string | typeof fetch,
+  altFetch = fetch,
+): Promise<boolean> {
+  // Remove UI-specific data to prevent parameter errors on the server
+  const cleanData = { ...data };
+  delete cleanData.label;
+  delete cleanData.extra_self_report_label;
+
+  const { token, customFetch } = resolveCsrfAndFetch(csrfOrFetch, altFetch);
+
+  try {
+    const response = await customFetch(
+      `${apiServer}/beta/tournaments/${tournamentId}/rounds/${roundId}/pairings/${pairingId}/report`,
+      {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+          "X-CSRF-Token": token,
+        },
+        body: JSON.stringify({
+          pairing: cleanData,
+          self_report: selfReport,
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      globalMessages.errors.push("Failed to report score.");
+      return false;
+    }
+
+    return true;
+  } catch (e) {
+    const err = e as Error;
+    globalMessages.errors.push(`Failed to report score: ${err.message}`);
+    return false;
+  }
+}
+
+export async function resetReports(
+  tournamentId: number,
+  roundId: number,
+  pairingId: number,
+  csrfOrFetch?: string | typeof fetch,
+  altFetch = fetch,
+): Promise<boolean> {
+  const { token, customFetch } = resolveCsrfAndFetch(csrfOrFetch, altFetch);
+
+  try {
+    const response = await customFetch(
+      `${apiServer}/beta/tournaments/${tournamentId}/rounds/${roundId}/pairings/${pairingId}/reset_self_report`,
+      {
+        method: "DELETE",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+          "X-CSRF-Token": token,
+        },
+      },
+    );
+
+    if (!response.ok) {
+      globalMessages.errors.push("Failed to reset self report.");
+      return false;
+    }
+
+    return true;
+  } catch (e) {
+    const err = e as Error;
+    globalMessages.errors.push(`Failed to reset self report: ${err.message}`);
+    return false;
+  }
 }

--- a/frontend/src/routes/tournaments/[tournamentId]/me/+page.svelte
+++ b/frontend/src/routes/tournaments/[tournamentId]/me/+page.svelte
@@ -1,0 +1,285 @@
+<script lang="ts">
+  import type { PageProps } from "./$types";
+  import { invalidateAll } from "$app/navigation";
+  import type { Pairing } from "$lib/model/Pairing";
+  import FontAwesomeIcon from "$lib/components/FontAwesomeIcon.svelte";
+  import PlayerDisplay from "$lib/components/PlayerDisplay.svelte";
+  import SelfReportOptions from "$lib/components/SelfReportOptions.svelte";
+  import { reportScore } from "../api_helper";
+  import type { ScoreReport } from "$lib/model/ScoreReport";
+  import Identity from "$lib/components/identity/Identity.svelte";
+  import {
+    CreateMyTournamentSummary,
+    type MyTournamentPairing,
+  } from "$lib/utils/transformations";
+
+  let { data }: PageProps = $props();
+
+  let tournament = $derived(data.tournamentData.tournament);
+  let tournamentId = $derived(tournament.id);
+  let userId = $derived(data.user?.id);
+  let pairings = $derived(data.pairings);
+
+  let showPreviousRounds = $state(false);
+
+  let numPairings = $derived(
+    pairings
+      ? pairings.stages.reduce(
+          (acc, s) =>
+            acc + s.rounds.reduce((acc, r) => acc + r.pairings.length, 0),
+          0,
+        )
+      : 0,
+  );
+
+  let me = $derived(CreateMyTournamentSummary(pairings, userId));
+
+  function isLatestRound(myPairing: MyTournamentPairing): boolean {
+    if (!pairings || pairings.stages.length === 0) return false;
+    const latestStage = pairings.stages[pairings.stages.length - 1];
+    if (!latestStage || latestStage.rounds.length === 0) return false;
+    const latestRound = latestStage.rounds[latestStage.rounds.length - 1];
+    return (
+      myPairing.stage.id === latestStage.id &&
+      myPairing.round.id === latestRound.id
+    );
+  }
+
+  function isBye(pairing: Pairing): boolean {
+    return pairing.player1.id === 0 || pairing.player2.id === 0;
+  }
+
+  function iWon(pairing: Pairing): boolean {
+    if (isBye(pairing) || !pairing.reported) return false;
+    const isMe1 = pairing.player1.user_id === userId;
+    const myScore = isMe1 ? pairing.score1 : pairing.score2;
+    const oppScore = isMe1 ? pairing.score2 : pairing.score1;
+    return myScore > oppScore;
+  }
+
+  function opponentWon(pairing: Pairing): boolean {
+    if (isBye(pairing) || !pairing.reported) return false;
+    const isMe1 = pairing.player1.user_id === userId;
+    const myScore = isMe1 ? pairing.score1 : pairing.score2;
+    const oppScore = isMe1 ? pairing.score2 : pairing.score1;
+    return oppScore > myScore;
+  }
+
+  function getScoreResultStyle(pairing: Pairing): string {
+    if (pairing.score_label.trim() === "" || pairing.score_label.trim() === "-") {
+      return "";
+    }
+    if (isBye(pairing) || iWon(pairing)) {
+      return "background-color: limegreen; color: black;";
+    }
+    if (opponentWon(pairing)) {
+      return "background-color: orangered; color: black;";
+    }
+    return "background-color: lightgrey; color: black;";
+  }
+
+  async function reportScoreCallback(
+    roundId: number,
+    pairingId: number,
+    report: ScoreReport,
+    selfReport: boolean,
+  ) {
+    const success = await reportScore(
+      tournamentId,
+      roundId,
+      pairingId,
+      report,
+      selfReport,
+      data.tournamentData?.csrf_token,
+    );
+    if (!success) {
+      return;
+    }
+
+    await invalidateAll();
+  }
+</script>
+
+<div class="col-12">
+{#if !data.player}
+  <div class="alert alert-warning">
+    <FontAwesomeIcon icon="exclamation-triangle" />
+    You are not registered as a player in this tournament.
+  </div>
+{:else}
+    {#if data}
+    <div class="container">
+        {#if numPairings > 0}
+        <div class="row mb-3 align-items-center">
+            <div class="col-12 col-md-4 d-flex flex-column justify-content-center text-center mt-3 mt-md-0">
+            <h2>Corp</h2>
+            {#if me.corpIdentity}
+                <div class="text-muted mb-2"><Identity identity={me.corpIdentity} /></div>
+            {/if}
+            <h4 class="text-bold">{me.corp.wins} - {me.corp.losses} - {me.corp.ties}</h4>
+            </div>
+
+            <div class="col-12 col-md-4 d-flex flex-column justify-content-center text-center mt-3 mt-md-0">
+            <h4>Total Points</h4>
+            <h1>{me.total.points}</h1>
+            <h4 class="text-bold">{me.total.wins} - {me.total.losses} - {me.total.ties}</h4>
+            </div>
+
+            <div class="col-12 col-md-4 d-flex flex-column justify-content-center text-center mt-3 mt-md-0">
+            <h2>Runner</h2>
+            {#if me.runnerIdentity}
+                <div class="text-muted mb-2"><Identity identity={me.runnerIdentity} /></div>
+            {/if}
+            <h4 class="text-bold">{me.runner.wins} - {me.runner.losses} - {me.runner.ties}</h4>
+            </div>
+        </div>
+        {/if}
+
+        {#if numPairings === 0}
+        <div class="row">
+            <div class="col-12">
+            <div class="alert alert-info">
+                <FontAwesomeIcon icon="info-circle" />
+                You don't have any pairings in this tournament yet.
+            </div>
+            </div>
+        </div>
+        {:else}
+        {#if numPairings > 1}
+            <div class="row">
+            <div class="col-12">
+                <button
+                class="btn btn-link btn-sm p-0 mb-2 d-flex align-items-center small"
+                onclick={() => (showPreviousRounds = !showPreviousRounds)}
+                >
+                <FontAwesomeIcon
+                    icon={showPreviousRounds ? "chevron-down" : "chevron-right"}
+                />
+                <span class="ml-2">
+                    {showPreviousRounds ? "Hide" : "Show"} previous rounds
+                </span>
+                </button>
+            </div>
+            </div>
+        {/if}
+
+        <div class="row col-12 table-responsive">
+            <table id="rounds_table" class="table">
+            <thead>
+                <tr>
+                <th>Round</th>
+                <th>Table</th>
+                {#if tournament.swiss_format === "single_sided"}
+                    <th>Side</th>
+                {/if}
+                <th>Opponent</th>
+                <th class="text-center">Result</th>
+                <th class="text-center">Points</th>
+                </tr>
+            </thead>
+            <tbody>
+                {#each me.pairings as myPairing (myPairing.id)}
+                {#if showPreviousRounds || isLatestRound(myPairing)}
+                    <tr>
+                    <td>
+                        {myPairing.stage.is_elimination ? "Cut " : ""}{myPairing.round.number}
+                    </td>
+                    <td>{isBye(myPairing) ? "" : myPairing.table_number}</td>
+                    {#if myPairing.stage.is_single_sided}
+                        <td class={iWon(myPairing) ? "font-weight-bold" : ""}>
+                        {#if !isBye(myPairing)}
+                            <PlayerDisplay
+                            player={myPairing.player1.user_id === userId
+                                ? myPairing.player1
+                                : myPairing.player2}
+                            pairing={myPairing}
+                            left_or_right="left"
+                            is_single_sided={myPairing.stage.is_single_sided}
+                            />
+                        {/if}
+                        </td>
+                    {/if}
+                    <td class={opponentWon(myPairing) ? "font-weight-bold" : ""}>
+                        {#if isBye(myPairing)}
+                        (Bye)
+                        {:else}
+                        <PlayerDisplay
+                            player={myPairing.player1.user_id === userId
+                            ? myPairing.player2
+                            : myPairing.player1}
+                            pairing={myPairing}
+                            left_or_right="left"
+                            is_single_sided={myPairing.stage.is_single_sided}
+                        />
+                        {/if}
+                    </td>
+                    <td class="text-center align-middle" style={getScoreResultStyle(myPairing)}>
+                        {#if myPairing.score_label.trim() !== "" && myPairing.score_label.trim() !== "-"}
+                        <div class="h4 mb-0 font-weight-bold">
+                            {#if isBye(myPairing) || iWon(myPairing)}
+                            W
+                            {:else if opponentWon(myPairing)}
+                            L
+                            {:else}
+                            T
+                            {/if}
+                        </div>
+                        {#if myPairing.intentional_draw}
+                            <span
+                            class="badge badge-pill badge-secondary score-badge"
+                            >
+                            ID
+                            </span>
+                        {/if}
+                        {#if myPairing.two_for_one}
+                            <span
+                            class="badge badge-pill badge-secondary score-badge"
+                            >
+                            2 for 1
+                            </span>
+                        {/if}
+                        {:else}
+                        {#if myPairing.policy.self_report}
+                            <SelfReportOptions
+                            stage={myPairing.stage}
+                            pairing={myPairing}
+                            reportScoreCallback={async (
+                                pairingId: number,
+                                report: ScoreReport,
+                                selfReport: boolean,
+                            ) => {
+                                await reportScoreCallback(
+                                myPairing.round.id,
+                                pairingId,
+                                report,
+                                selfReport,
+                                );
+                            }}
+                            />
+                        {/if}
+                        {#if myPairing.self_reports && myPairing.self_reports.length !== 0}
+                            Report: {myPairing.self_reports[0].label}
+                        {/if}
+                        {/if}
+                    </td>
+                    <td class="text-center align-middle">
+                        {#if myPairing.cumulativePoints !== null}
+                        {myPairing.cumulativePoints}
+                        {/if}
+                    </td>
+                    </tr>
+                {/if}
+                {/each}
+            </tbody>
+            </table>
+        </div>
+        {/if}
+    </div>
+    {:else}
+    <div class="d-flex align-items-center m-2">
+        <div class="spinner-border m-auto"></div>
+    </div>
+    {/if}
+
+{/if}
+</div>

--- a/frontend/src/routes/tournaments/[tournamentId]/me/+page.svelte
+++ b/frontend/src/routes/tournaments/[tournamentId]/me/+page.svelte
@@ -37,7 +37,7 @@
   function isLatestRound(myPairing: MyTournamentPairing): boolean {
     if (!pairings || pairings.stages.length === 0) return false;
     const latestStage = pairings.stages[pairings.stages.length - 1];
-    if (!latestStage || latestStage.rounds.length === 0) return false;
+    if (latestStage.rounds.length === 0) return false;
     const latestRound = latestStage.rounds[latestStage.rounds.length - 1];
     return (
       myPairing.stage.id === latestStage.id &&
@@ -90,7 +90,7 @@
       pairingId,
       report,
       selfReport,
-      data.tournamentData?.csrf_token,
+      data.tournamentData.csrf_token,
     );
     if (!success) {
       return;

--- a/frontend/src/routes/tournaments/[tournamentId]/me/+page.ts
+++ b/frontend/src/routes/tournaments/[tournamentId]/me/+page.ts
@@ -2,7 +2,7 @@ import type { PageLoad } from "./$types";
 import { loadPairings } from "../api_helper";
 import { authStore } from "$lib/utils/auth.svelte";
 
-export const load: PageLoad = async ({ parent, params, fetch }) => {
+export const load: PageLoad = async ({ parent, fetch }) => {
   const { player, tournamentData } = await parent();
   const user = authStore.user;
 

--- a/frontend/src/routes/tournaments/[tournamentId]/me/+page.ts
+++ b/frontend/src/routes/tournaments/[tournamentId]/me/+page.ts
@@ -1,0 +1,17 @@
+import type { PageLoad } from "./$types";
+import { loadPairings } from "../api_helper";
+import { authStore } from "$lib/utils/auth.svelte";
+
+export const load: PageLoad = async ({ parent, params, fetch }) => {
+  const { player, tournamentData } = await parent();
+  const user = authStore.user;
+
+  return {
+    user: user,
+    player: player,
+    pairings:
+      !player || !user
+        ? null
+        : await loadPairings(tournamentData.tournament.id, user.id, fetch),
+  };
+};

--- a/frontend/src/routes/tournaments/api_helper.ts
+++ b/frontend/src/routes/tournaments/api_helper.ts
@@ -10,6 +10,8 @@ import type { TournamentsResponse } from "$lib/utils/api_types";
 import { ValidationError, type Errors } from "$lib/utils/errors";
 import { globalMessages } from "$lib/utils/GlobalMessageState.svelte";
 
+const apiServer = (COBRA_API_SERVER || "").replace(/\/$/, "");
+
 export interface TournamentData {
   tournament: Tournament,
   csrf_token: string,
@@ -32,9 +34,17 @@ export interface TournamentCreateErrorResponse {
   errors: Errors;
 }
 
+export function csrfToken() {
+  return typeof document !== "undefined"
+    ? (document
+        .querySelector("meta[name='csrf-token']")
+        ?.getAttribute("content") ?? "")
+    : "";
+}
+
 export async function loadTournament(tournamentId: number, altFetch = fetch) {
   const response = await altFetch(
-    `${COBRA_API_SERVER}/beta/tournaments/${tournamentId}`,
+    `${apiServer}/beta/tournaments/${tournamentId}`,
     {
       method: "GET",
       credentials: "include",
@@ -73,7 +83,7 @@ export async function loadTournaments(url: string, altFetch = fetch): Promise<To
 
 export function tournamentsApiUrl(tournamentTypeId?: string): string {
   const query = [
-    `${COBRA_API_SERVER}/api/v1/public/tournaments?page[size]=10`,
+    `${apiServer}/api/v1/public/tournaments?page[size]=10`,
     "include=tournament_type",
     "sort=-date,name",
   ];
@@ -88,7 +98,7 @@ export function tournamentsApiUrl(tournamentTypeId?: string): string {
 export async function loadNewTournament(
   fetch: typeof globalThis.fetch,
 ): Promise<TournamentSettingsData> {
-  const response = await fetch(`${COBRA_API_SERVER}/tournaments/new_form`, {
+  const response = await fetch(`${apiServer}/tournaments/new_form`, {
     credentials: "include",
     headers: { Accept: "application/json" },
     method: "GET",
@@ -104,7 +114,7 @@ export async function createTournament(
   csrfToken: string,
   tournament: Tournament,
 ): Promise<TournamentCreateResponse> {
-  const response = await fetch(`${COBRA_API_SERVER}/tournaments`, {
+  const response = await fetch(`${apiServer}/tournaments`, {
     method: "POST",
     credentials: "include",
     headers: {
@@ -129,7 +139,7 @@ export async function createTournament(
 export async function loadPlayerByUserId(tournamentId: number, userId: number, altFetch = fetch) {
   try {
     const response = await altFetch(
-      `${COBRA_API_SERVER}/beta/tournaments/${tournamentId}/players/by_user_id/${userId}`,
+      `${apiServer}/beta/tournaments/${tournamentId}/players/by_user_id/${userId}`,
       {
         method: "GET",
         credentials: "include",
@@ -149,8 +159,8 @@ export async function savePlayer(
 ) {
   const route =
     player.id === 0
-      ? `${COBRA_API_SERVER}/beta/tournaments/${tournamentId}/players`
-      : `${COBRA_API_SERVER}/beta/tournaments/${tournamentId}/player/${player.id}`;
+      ? `${apiServer}/beta/tournaments/${tournamentId}/players`
+      : `${apiServer}/beta/tournaments/${tournamentId}/player/${player.id}`;
   const response = await fetch(route, {
     method: player.id === 0 ? "POST" : "PATCH",
     credentials: "include",
@@ -175,7 +185,7 @@ export async function savePlayer(
 }
 
 export async function loadIdentityNames() {
-  const response = await fetch(`${COBRA_API_SERVER}/beta/identities`, {
+  const response = await fetch(`${apiServer}/beta/identities`, {
     method: "GET",
   });
 
@@ -183,7 +193,7 @@ export async function loadIdentityNames() {
 }
 
 export async function loadCurrentRoundTimer(tournamentId: number, csrfToken?: string) {
-  const response = await fetch(`${COBRA_API_SERVER}/beta/tournaments/${tournamentId}/current_round_timer`, {
+  const response = await fetch(`${apiServer}/beta/tournaments/${tournamentId}/current_round_timer`, {
     method: "GET",
     credentials: "include",
     headers: {
@@ -240,7 +250,7 @@ function cardRequestObject(card: Card) {
 
 export async function loadStandings(tournamentId: number, altFetch = fetch): Promise<StandingsData> {
   const response = await altFetch(
-    `${COBRA_API_SERVER}/tournaments/${tournamentId}/players/standings_data`,
+    `${apiServer}/tournaments/${tournamentId}/players/standings_data`,
     {
       method: "GET",
       credentials: "include",
@@ -258,7 +268,7 @@ export async function loadStandings(tournamentId: number, altFetch = fetch): Pro
 
 export async function loadBrackets(tournamentId: number, altFetch = fetch): Promise<BracketData> {
   const response = await altFetch(
-    `${COBRA_API_SERVER}/tournaments/${tournamentId}/rounds/brackets`,
+    `${apiServer}/tournaments/${tournamentId}/rounds/brackets`,
     {
       method: "GET",
     },


### PR DESCRIPTION
Add the 'Me' tab to frontend/. Do a bunch of shuffling around a litttttle bit of tidying up.

<img width="1032" height="630" alt="Screenshot 2026-09-09 at 12 22 22 AM" src="https://github.com/user-attachments/assets/9587d80d-975e-4e29-90a5-2fc9e3480270" />
